### PR TITLE
Add quotes to shader attribute names

### DIFF
--- a/docs/next/reference/buffer_format.rst
+++ b/docs/next/reference/buffer_format.rst
@@ -246,9 +246,9 @@ call::
     vao = ctx.vertex_array(
         shader_program,
         [
-            (vbo_verts_normals,      "3f 3f /v", in_vert, in_norm),
-            (vbo_offset_orientation, "3f 9f /i", in_offset, in_orientation),
-            (vbo_colors,             "3f /r",    in_color),
+            (vbo_verts_normals,      "3f 3f /v", "in_vert", "in_norm"),
+            (vbo_offset_orientation, "3f 9f /i", "in_offset", "in_orientation"),
+            (vbo_colors,             "3f /r",    "in_color"),
         ]
         index_buffer_object
     )

--- a/docs/reference/buffer_format.rst
+++ b/docs/reference/buffer_format.rst
@@ -246,9 +246,9 @@ call::
     vao = ctx.vertex_array(
         shader_program,
         [
-            (vbo_verts_normals,      "3f 3f /v", in_vert, in_norm),
-            (vbo_offset_orientation, "3f 9f /i", in_offset, in_orientation),
-            (vbo_colors,             "3f /r",    in_color),
+            (vbo_verts_normals,      "3f 3f /v", "in_vert", "in_norm"),
+            (vbo_offset_orientation, "3f 9f /i", "in_offset", "in_orientation"),
+            (vbo_colors,             "3f /r",    "in_color"),
         ]
         index_buffer_object
     )


### PR DESCRIPTION
### Description

Tiny fix for the recently-merged "buffer formats" documentation pages.

### List of changes

Some shader attribute names needed quotes where they are named in Python source.

Fixed in buffer_formats.rst for both v5 and v6.
