### PR TITLE
Added support for glProvokingVertex

### DIFF
--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -24,7 +24,7 @@ __all__ = ['Context', 'create_context', 'create_standalone_context',
            'NOTHING', 'BLEND', 'DEPTH_TEST', 'CULL_FACE', 'RASTERIZER_DISCARD',
            'ZERO', 'ONE', 'SRC_COLOR', 'ONE_MINUS_SRC_COLOR', 'SRC_ALPHA', 'ONE_MINUS_SRC_ALPHA', 'DST_ALPHA',
            'ONE_MINUS_DST_ALPHA', 'DST_COLOR', 'ONE_MINUS_DST_COLOR',
-           'DEFAULT_BLENDING', 'PREMULTIPLIED_ALPHA',
+           'DEFAULT_BLENDING', 'PREMULTIPLIED_ALPHA', 'FIRST_VERTEX_CONVENTION', 'LAST_VERTEX_CONVENTION'
 ]
 
 
@@ -46,6 +46,8 @@ ONE_MINUS_DST_ALPHA = 0x0305
 DST_COLOR = 0x0306
 ONE_MINUS_DST_COLOR = 0x0307
 
+FIRST_VERTEX_CONVENTION = 0x8E4D
+LAST_VERTEX_CONVENTION = 0x8E4E
 
 DEFAULT_BLENDING = (SRC_ALPHA, ONE_MINUS_SRC_ALPHA)
 PREMULTIPLIED_ALPHA = (SRC_ALPHA, ONE)
@@ -97,6 +99,10 @@ class Context:
     @point_size.setter
     def point_size(self, value):
         self.mglo.point_size = value
+
+    @property
+    def provoking_vertex(self):
+        self.mglo.provoking_vertex()
 
     @property
     def depth_func(self) -> str:
@@ -158,6 +164,22 @@ class Context:
     @multisample.setter
     def multisample(self, value):
         self.mglo.multisample = value
+
+    @property
+    def provoking_vertex(self):
+        '''
+            This property is write only
+
+            Example::
+                
+                ctx.provoking_vertex = moderngl.FIRST_VERTEX_CONVENTION
+        '''
+        raise NotImplementedError()
+
+
+    @provoking_vertex.setter
+    def provoking_vertex(self, value):
+        self.mglo.provoking_vertex = value
 
     @property
     def viewport(self) -> Tuple[int, int, int, int]:

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -588,6 +588,22 @@ int MGLContext_set_multisample(MGLContext * self, PyObject * value) {
 	return -1;
 }
 
+int MGLContext_get_provoking_vertex(MGLContext * self) {
+	return self->provoking_vertex;
+}
+
+int MGLContext_set_provoking_vertex(MGLContext * self, PyObject * value) {
+	int provoking_vertex_value = PyLong_AsLong(value);
+	const GLMethods & gl = self->gl;
+
+	if (provoking_vertex_value == GL_FIRST_VERTEX_CONVENTION || provoking_vertex_value == GL_LAST_VERTEX_CONVENTION) {
+		gl.ProvokingVertex(provoking_vertex_value);
+		self->provoking_vertex = provoking_vertex_value;
+		return 0;
+	}
+	return -1;
+}
+
 PyObject * MGLContext_get_default_texture_unit(MGLContext * self) {
 	return PyLong_FromLong(self->default_texture_unit);
 }
@@ -1255,6 +1271,8 @@ PyGetSetDef MGLContext_tp_getseters[] = {
 	{(char *)"blend_func", (getter)MGLContext_get_depth_func, (setter)MGLContext_set_blend_func, 0, 0},
 	{(char *)"multisample", (getter)MGLContext_get_multisample, (setter)MGLContext_set_multisample, 0, 0},
 
+	{(char *)"provoking_vertex", (getter)MGLContext_get_provoking_vertex, (setter)MGLContext_set_provoking_vertex, 0, 0},
+
 	{(char *)"default_texture_unit", (getter)MGLContext_get_default_texture_unit, (setter)MGLContext_set_default_texture_unit, 0, 0},
 	{(char *)"max_samples", (getter)MGLContext_get_max_samples, 0, 0, 0},
 	{(char *)"max_integer_samples", (getter)MGLContext_get_max_integer_samples, 0, 0, 0},
@@ -1429,5 +1447,7 @@ void MGLContext_Initialize(MGLContext * self) {
 
 	self->wireframe = false;
 	self->multisample = true;
+
+	self->provoking_vertex = GL_LAST_VERTEX_CONVENTION;
 	gl.GetError(); // clear errors
 }

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -128,6 +128,8 @@ struct MGLContext {
 	bool wireframe;
 	bool multisample;
 
+	int provoking_vertex;
+
 	GLMethods gl;
 };
 


### PR DESCRIPTION
### Description

Added support for glProvokingVertex by adding the functionality to the Context object.

### List of changes

Added a write-only property in context.py as well as two necessary global enums (FIRST_VERTEX_CONVENTION, and LAST_VERTEX_CONVENTION)

### Example usage: 
```
ctx = moderngl.create_standalone_context()
ctx.provoking_vertex = moderngl.FIRST_VERTEX_CONVENTION
```