### PR TITLE
fix dead link to prospector web site

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Code is tested with [pep8], [flake8], [prospector] and [pylint]
 
 [pep8]: https://www.python.org/dev/peps/pep-0008/
 [flake8]: http://flake8.pycqa.org/en/latest/
-[prospector]: https://prospector.landscape.io/en/master/
+[prospector]: https://prospector.readthedocs.io/en/master/
 [pylint]: https://www.pylint.org/
 [moderngl-window]: https://github.com/moderngl/moderngl-window
 


### PR DESCRIPTION
### Description

Fix dead link to prospector web site in README.md (the new link is the official documentation).
