### PR TITLE
Adding Texture transfer

### DIFF
--- a/moderngl/buffer.py
+++ b/moderngl/buffer.py
@@ -270,3 +270,20 @@ class Buffer:
             (self, index) tuple
         """
         return (self, index)
+
+    def transfer(self, context):
+        '''
+            share the buffer to a new context
+
+            Args:
+                context (:py:class:`Texture`): shared context
+            Returns:
+                :py:class:`Buffer` object
+        '''
+        res = Buffer.__new__(Buffer)
+        res.mglo, res._glo = self.mglo.transfer(context.mglo)
+        res._size = self._size
+        res._dynamic = self._dynamic
+        res.ctx = context
+        res.extra = self.extra
+        return res

--- a/moderngl/old/Texture.cpp
+++ b/moderngl/old/Texture.cpp
@@ -266,6 +266,7 @@ PyObject * MGLContext_depth_texture(MGLContext * self, PyObject * args) {
 
 	texture->repeat_x = false;
 	texture->repeat_y = false;
+	texture->reference = nullptr;
 
 	Py_INCREF(self);
 	texture->context = self;
@@ -285,27 +286,6 @@ PyObject * MGLTexture_tp_new(PyTypeObject * type, PyObject * args, PyObject * kw
 	}
 
 	return (PyObject *)self;
-}
-
-PyObject * MGLTexture_transfer(MGLTexture* self, PyObject* args) {
-	MGLContext* context;
-	bool args_ok = PyArg_ParseTuple(
-		args,
-		"O!",
-		&MGLContext_Type,
-		&context);
-	if (!args_ok) return 0;
-	// TODO: to check if the texture is sharable amongst old and new context
-	MGLTexture* new_texture = new MGLTexture(*self);
-	Py_INCREF(context);
-	Py_INCREF(new_texture);
-	Py_INCREF(self);
-	new_texture->context = context;
-	new_texture->reference = self;
-	PyObject * result = PyTuple_New(2);
-	PyTuple_SET_ITEM(result, 0, (PyObject *)new_texture);
-	PyTuple_SET_ITEM(result, 1, PyLong_FromLong(new_texture->texture_obj));
-	return result;
 }
 
 void MGLTexture_tp_dealloc(MGLTexture * self) {
@@ -676,6 +656,27 @@ PyObject * MGLTexture_build_mipmaps(MGLTexture * self, PyObject * args) {
 	self->max_level = max;
 
 	Py_RETURN_NONE;
+}
+
+PyObject * MGLTexture_transfer(MGLTexture * self, PyObject * args) {
+	MGLContext* context;
+	bool args_ok = PyArg_ParseTuple(
+			args,
+			"O!",
+			&MGLContext_Type,
+			&context);
+	if (!args_ok) return 0;
+	// TODO: to check if the texture is sharable amongst old and new context
+	MGLTexture* new_texture = new MGLTexture(*self);
+	Py_INCREF(context);
+	Py_INCREF(new_texture);
+	Py_INCREF(self);
+	new_texture->context = context;
+	new_texture->reference = self;
+	PyObject * result = PyTuple_New(2);
+	PyTuple_SET_ITEM(result, 0, (PyObject *)new_texture);
+	PyTuple_SET_ITEM(result, 1, PyLong_FromLong(new_texture->texture_obj));
+	return result;
 }
 
 PyObject * MGLTexture_release(MGLTexture * self) {

--- a/moderngl/old/Types.hpp
+++ b/moderngl/old/Types.hpp
@@ -88,6 +88,8 @@ struct MGLBuffer {
 
 	Py_ssize_t size;
 	bool dynamic;
+
+	MGLBuffer* reference;
 };
 
 struct MGLComputeShader {
@@ -292,6 +294,7 @@ struct MGLTexture3D {
 	bool repeat_x;
 	bool repeat_y;
 	bool repeat_z;
+	MGLTexture3D* reference;
 };
 
 struct MGLTextureArray {
@@ -317,6 +320,8 @@ struct MGLTextureArray {
 	bool repeat_x;
 	bool repeat_y;
 	float anisotropy;
+
+	MGLTextureArray* reference;
 };
 
 struct MGLTextureCube {
@@ -337,6 +342,8 @@ struct MGLTextureCube {
 	int mag_filter;
 	int max_level;
 	float anisotropy;
+
+	MGLTextureCube* reference;
 };
 
 struct MGLUniform {

--- a/moderngl/old/Types.hpp
+++ b/moderngl/old/Types.hpp
@@ -268,6 +268,7 @@ struct MGLTexture {
 
 	bool repeat_x;
 	bool repeat_y;
+	MGLTexture* reference;
 };
 
 struct MGLTexture3D {

--- a/moderngl/texture.py
+++ b/moderngl/texture.py
@@ -350,3 +350,18 @@ class Texture:
         '''
 
         self.mglo.release()
+
+    def transfer(self, context) -> 'Texture':
+        '''
+            create a reference texture under another sharable context
+        '''
+        res = Texture.__new__(Texture)
+        res.mglo, res._glo = self.mglo.transfer(context.mglo)
+        res._size = self._size
+        res._components = self._components
+        res._samples = self._samples
+        res._dtype = self._dtype
+        res._depth = self._depth
+        res.ctx = context
+        res.extra = self.extra
+        return res

--- a/moderngl/texture.py
+++ b/moderngl/texture.py
@@ -353,7 +353,12 @@ class Texture:
 
     def transfer(self, context) -> 'Texture':
         '''
-            create a reference texture under another sharable context
+            share the texture to a new context
+
+            Args:
+                context (:py:class:`Context`): shared context
+            Returns:
+                :py:class:`Texture` object
         '''
         res = Texture.__new__(Texture)
         res.mglo, res._glo = self.mglo.transfer(context.mglo)

--- a/moderngl/texture_3d.py
+++ b/moderngl/texture_3d.py
@@ -278,3 +278,23 @@ class Texture3D:
         '''
 
         self.mglo.release()
+
+    def transfer(self, context) -> 'Texture3D':
+        '''
+            share the texture to a new context
+
+            Args:
+                context (:py:class:`Context`): shared context
+            Returns:
+                :py:class:`Texture3D` object
+        '''
+        res = Texture3D.__new__(Texture3D)
+        res.mglo, res._glo = self.mglo.transfer(context.mglo)
+        res._size = self._size
+        res._components = self._components
+        res._samples = self._samples
+        res._dtype = self._dtype
+        res._depth = self._depth
+        res.ctx = context
+        res.extra = self.extra
+        return res

--- a/moderngl/texture_array.py
+++ b/moderngl/texture_array.py
@@ -287,3 +287,23 @@ class TextureArray:
         '''
 
         self.mglo.release()
+
+    def transfer(self, context) -> 'TextureArray':
+        '''
+            share the texture to a new context
+
+            Args:
+                context (:py:class:`Context`): shared context
+            Returns:
+                :py:class:`TextureArray` object
+        '''
+        res = TextureArray.__new__(TextureArray)
+        res.mglo, res._glo = self.mglo.transfer(context.mglo)
+        res._size = self._size
+        res._components = self._components
+        res._samples = self._samples
+        res._dtype = self._dtype
+        res._depth = self._depth
+        res.ctx = context
+        res.extra = self.extra
+        return res

--- a/moderngl/texture_cube.py
+++ b/moderngl/texture_cube.py
@@ -207,3 +207,23 @@ class TextureCube:
         '''
 
         self.mglo.release()
+
+    def transfer(self, context) -> 'TextureCube':
+        '''
+            share the texure to a new context
+
+            Args:
+                context (:py:class:`TextureCube`): shared context
+            Returns:
+                :py:class:`TextureCube` object
+        '''
+        res = TextureCube.__new__(TextureCube)
+        res.mglo, res._glo = self.mglo.transfer(context.mglo)
+        res._size = self._size
+        res._components = self._components
+        res._samples = self._samples
+        res._dtype = self._dtype
+        res._depth = self._depth
+        res.ctx = context
+        res.extra = self.extra
+        return res

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -146,6 +146,17 @@ class TestCase(unittest.TestCase):
         texture.read_into(pbo)
 
         self.assertEqual(pbo.read(), pixels)
+    
+    def test_7(self):
+        pixels = struct.pack('16B', 255, 0, 0, 255, 0, 255, 0, 255, 255, 0, 0, 255, 0, 255, 0, 255)
+        texture1 = self.ctx.texture((2, 2), 4, pixels)
+        texture2 = texture1.transfer(self.ctx)
+        pbo1 = self.ctx.buffer(reserve=len(pixels))
+        pbo2 = self.ctx.buffer(reserve=len(pixels))
+        texture1.read_into(pbo1)
+        texture2.read_into(pbo2)
+        self.assertEqual(pbo1.read(), pbo2.read())
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description

Trying to pull with issue #367.
All data types (buffers/textures) can be sharable between contexts.

Adding `texture.transfer(ctx)` to share between context

### List of changes

- **added** ...
`Texture.transfer`
`Texture3D.transfer`
`TextureCube.transfer`
`TextureArray.transfer`
`Buffer.transfer`

I have listed my changes. However, it is only a temporary solution.
A problem I could see with this solution comes from synchronisation.

A better solution is to create a new type that refers to the original object and operates
on that object.
<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
