### PR TITLE
Allow Face Culling

### DIFF
--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -478,6 +478,30 @@ class Context:
         self.mglo.front_face = str(value)
 
     @property
+    def cull_face(self) -> str:
+        '''
+            str: The cull_face. Acceptable values are ``'back'`` (default) ``'front'`` or ``'front_and_back'``.
+
+            Face culling must be enabled for this to have any effect:
+            ``ctx.enable(moderngl.CULL_FACE)``.
+
+            Example::
+
+                #
+                ctx.cull_face = 'front'
+                #
+                ctx.cull_face = 'back'
+                #
+                ctx.cull_face = 'front_and_back'
+        '''
+
+        return self.mglo.cull_face
+
+    @cull_face.setter
+    def cull_face(self, value):
+        self.mglo.cull_face = str(value)
+
+    @property
     def patch_vertices(self) -> int:
         '''
             int: The number of vertices that will be used to make up a single patch

--- a/moderngl/src/Context.cpp
+++ b/moderngl/src/Context.cpp
@@ -769,6 +769,41 @@ int MGLContext_set_front_face(MGLContext * self, PyObject * value) {
 	return 0;
 }
 
+PyObject * MGLContext_get_cull_face(MGLContext * self) {
+	if (self->front_face == GL_FRONT) {
+		static PyObject * res_cw = PyUnicode_FromString("front");
+		Py_INCREF(res_cw);
+		return res_cw;
+	}
+	else if (self->front_face == GL_BACK) {
+		static PyObject * res_cw = PyUnicode_FromString("back");
+		Py_INCREF(res_cw);
+		return res_cw;
+	}
+	static PyObject * res_ccw = PyUnicode_FromString("front_and_back");
+	Py_INCREF(res_ccw);
+	return res_ccw;
+}
+
+int MGLContext_set_cull_face(MGLContext * self, PyObject * value) {
+	const char * str = PyUnicode_AsUTF8(value);
+
+	if (!strcmp(str, "front")) {
+		self->cull_face = GL_FRONT;
+	} else if (!strcmp(str, "back")) {
+		self->cull_face = GL_BACK;
+    } else if (!strcmp(str, "front_and_back")) {
+		self->cull_face = GL_FRONT_AND_BACK;
+	} else {
+		MGLError_Set("invalid cull_face");
+		return -1;
+	}
+
+	self->gl.CullFace(self->cull_face);
+	return 0;
+}
+
+
 PyObject * MGLContext_get_patch_vertices(MGLContext * self) {
 	int patch_vertices = 0;
 
@@ -1349,6 +1384,7 @@ PyGetSetDef MGLContext_tp_getseters[] = {
 
 	{(char *)"wireframe", (getter)MGLContext_get_wireframe, (setter)MGLContext_set_wireframe, 0, 0},
 	{(char *)"front_face", (getter)MGLContext_get_front_face, (setter)MGLContext_set_front_face, 0, 0},
+	{(char *)"cull_face", (getter)MGLContext_get_cull_face, (setter)MGLContext_set_cull_face, 0, 0},
 
 	{(char *)"patch_vertices", (getter)MGLContext_get_patch_vertices, (setter)MGLContext_set_patch_vertices, 0, 0},
 

--- a/moderngl/src/Types.hpp
+++ b/moderngl/src/Types.hpp
@@ -123,6 +123,7 @@ struct MGLContext {
 
 	int enable_flags;
 	int front_face;
+	int cull_face;
 
 	int depth_func;
 	int blend_func_src;

--- a/tests/test_cull_face.py
+++ b/tests/test_cull_face.py
@@ -1,0 +1,46 @@
+"""
+
+"""
+import numpy as np
+
+import moderngl as mgl
+
+
+def test_cull_face(standalone_context,
+                   prog_render_depth_pass,
+                   vbo_triangle,
+                   fbo_with_rasterised_triangle,
+                   np_triangle_rasterised):
+    ctx = standalone_context
+
+    size = (16,) * 2
+
+    ctx.enable(mgl.DEPTH_TEST)
+    ctx.enable(mgl.CULL_FACE)
+
+    def _do_test_cull_face(cull_face: str, expected_results: np.array):
+        ctx.cull_face = cull_face
+        fbo_depth, tex_depth = fbo_with_rasterised_triangle(prog_render_depth_pass, size)
+        depth_from_dbo = np.frombuffer(tex_depth.read(), dtype=np.dtype('f4')).reshape(size[::-1])
+        np.testing.assert_array_almost_equal(depth_from_dbo, expected_results)
+
+    ############################################################################
+    # EXPECTED DATAS                                                                                                   #
+    # It should have 0.5's where the triangle lies.                                                                    #
+    ############################################################################
+    np_triangle_raster = np_triangle_rasterised(size)
+    ############################################################################
+    # cull face is set to back, only one 'front' triangle in the scene => no culling
+    _do_test_cull_face('back', np_triangle_raster)
+
+    ############################################################################
+    # EXPECTED DATAS                                                                                                   #
+    # It should have 1.0's everywhere.                                                                    #
+    ############################################################################
+    np_clear_depth = np.full(size, 1.0)
+    ############################################################################
+    # cull face is set to front, only one 'front' triangle in the scene => the triangle is culled
+    _do_test_cull_face('front', np_clear_depth)
+
+    # cull face is set to front_and_back, only one 'front' triangle in the scene => the triangle is culled
+    _do_test_cull_face('front_and_back', np_clear_depth)


### PR DESCRIPTION
Refer to issue: https://github.com/moderngl/moderngl/issues/384

### Description

Allow to set the cull face mode: `back` (default value), `front` and `fron_and_back`.
OpenGL documentation: https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCullFace.xhtml

### List of changes

- **added**
  - API in C++ code to use `cull_face` property
  - API in Python to get and set the new property in context: `cull_face`
  - Unit test `test_cull_face.py` for testing the functionnality
- ~**removed**~
- ~**fixed**~
- **changed**
  - Update `test_depth_samplers` for mutualise fixtures with the new unit test

<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
