### PR TITLE
Fix catching a context creation error

### DIFF
--- a/examples/context_manager.py
+++ b/examples/context_manager.py
@@ -13,7 +13,7 @@ class ContextManager:
         if ContextManager.ctx is None:
             try:
                 ContextManager.ctx = moderngl.create_context()
-            except moderngl.Error:
+            except:
                 if allow_fallback_standalone_context:
                     ContextManager.ctx = moderngl.create_standalone_context()
                 else:


### PR DESCRIPTION
With the switch tot glcontext, it seems a base `Exception` is raised from `moderngl.create_context()` instead of a `moderngl.Error` previously.
