### PR TITLE
Update _example.py

### DIFF
--- a/examples/ported/_example.py
+++ b/examples/ported/_example.py
@@ -9,7 +9,7 @@ class Example(mglw.WindowConfig):
     window_size = (1280, 720)
     aspect_ratio = 16 / 9
     resizable = True
-    samples = 4
+    #samples = 4 #this will cause an error of pyglet.window.nosuchconfigexception on Ubuntu. SO remove it?
 
     resource_dir = os.path.normpath(os.path.join(__file__, '../../data'))
 


### PR DESCRIPTION

### Description

Examples work fine on MacOS, but fail on Ubuntu 18.04 with the following issue.
ubuntu pyglet window.nosuchconfigexception

### List of changes

remove "samples = 4" to fix the issue
<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
