### PR TITLE
[Draft] Use glUniformX instead of glProgramUniformX

### DIFF
--- a/moderngl/src/Types.hpp
+++ b/moderngl/src/Types.hpp
@@ -351,7 +351,6 @@ struct MGLUniform {
 
 	MGLProc value_getter;
 	MGLProc value_setter;
-	MGLProc gl_get_integer_proc;
 	MGLProc gl_use_program_prog;
 	MGLProc gl_value_reader_proc;
 	MGLProc gl_value_writer_proc;

--- a/moderngl/src/Types.hpp
+++ b/moderngl/src/Types.hpp
@@ -351,6 +351,8 @@ struct MGLUniform {
 
 	MGLProc value_getter;
 	MGLProc value_setter;
+	MGLProc gl_get_integer_proc;
+	MGLProc gl_use_program_prog;
 	MGLProc gl_value_reader_proc;
 	MGLProc gl_value_writer_proc;
 

--- a/moderngl/src/Uniform.cpp
+++ b/moderngl/src/Uniform.cpp
@@ -45,17 +45,13 @@ int MGLUniform_set_data(MGLUniform * self, PyObject * value, void * closure) {
 		return -1;
 	}
 
-	GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
-    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	if (self->matrix) {
 		((gl_uniform_matrix_writer_proc)self->gl_value_writer_proc)(self->location, self->array_length, false, buffer_view.buf);
 	} else {
 		((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, self->array_length, buffer_view.buf);
 	}
-
-	((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	PyBuffer_Release(&buffer_view);
 	return 0;
@@ -120,7 +116,6 @@ void MGLUniform_Invalidate(MGLUniform * uniform) {
 }
 
 void MGLUniform_Complete(MGLUniform * self, const GLMethods & gl) {
-    self->gl_get_integer_proc = (MGLProc)gl.GetIntegerv;
     self->gl_use_program_prog = (MGLProc)gl.UseProgram;
 	switch (self->type) {
 		case GL_BOOL:

--- a/moderngl/src/UniformGetSetters.hpp
+++ b/moderngl/src/UniformGetSetters.hpp
@@ -4,8 +4,10 @@
 
 
 typedef void (GLAPI * gl_uniform_reader_proc)(GLuint program, GLint location, void * value);
-typedef void (GLAPI * gl_uniform_vector_writer_proc)(GLuint program, GLint location, GLsizei count, const void * value);
-typedef void (GLAPI * gl_uniform_matrix_writer_proc)(GLuint program, GLint location, GLsizei count, GLboolean transpose, const void * value);
+typedef void (GLAPI * gl_uniform_vector_writer_proc)(GLint location, GLsizei count, const void * value);
+typedef void (GLAPI * gl_uniform_matrix_writer_proc)(GLint location, GLsizei count, GLboolean transpose, const void * value);
+typedef void (GLAPI * gl_use_program_proc)(GLuint program);
+typedef void (GLAPI * gl_get_intergerv_proc)(GLenum pname, GLint * data);
 
 typedef PyObject * (* MGLUniform_Getter)(MGLUniform * self);
 typedef int (* MGLUniform_Setter)(MGLUniform * self, PyObject * value);

--- a/moderngl/src/UniformSetters.cpp
+++ b/moderngl/src/UniformSetters.cpp
@@ -19,11 +19,8 @@ int MGLUniform_bool_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -36,11 +33,8 @@ int MGLUniform_int_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -53,11 +47,8 @@ int MGLUniform_uint_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -70,11 +61,9 @@ int MGLUniform_float_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
+
 
 	return 0;
 }
@@ -87,11 +76,8 @@ int MGLUniform_double_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -104,11 +90,8 @@ int MGLUniform_sampler_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -143,11 +126,8 @@ int MGLUniform_bool_array_value_setter(MGLUniform * self, PyObject * value) {
 		}
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -179,11 +159,8 @@ int MGLUniform_int_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -215,11 +192,8 @@ int MGLUniform_uint_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -251,11 +225,8 @@ int MGLUniform_float_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -287,11 +258,8 @@ int MGLUniform_double_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -323,11 +291,8 @@ int MGLUniform_sampler_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -362,11 +327,8 @@ int MGLUniform_bvec_value_setter(MGLUniform * self, PyObject * value) {
 		}
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -396,11 +358,8 @@ int MGLUniform_ivec_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -430,11 +389,8 @@ int MGLUniform_uvec_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -464,11 +420,8 @@ int MGLUniform_vec_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -498,11 +451,8 @@ int MGLUniform_dvec_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -557,11 +507,8 @@ int MGLUniform_bvec_array_value_setter(MGLUniform * self, PyObject * value) {
 		}
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -613,11 +560,8 @@ int MGLUniform_ivec_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -669,11 +613,8 @@ int MGLUniform_uvec_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -725,11 +666,8 @@ int MGLUniform_vec_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -781,11 +719,8 @@ int MGLUniform_dvec_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -816,11 +751,8 @@ int MGLUniform_matrix_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_matrix_writer_proc)self->gl_value_writer_proc)(self->location, 1, false, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -871,11 +803,8 @@ int MGLUniform_matrix_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-    GLint current_program;
-    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
     ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 	((gl_uniform_matrix_writer_proc)self->gl_value_writer_proc)(self->location, size, false, c_values);
-    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;

--- a/moderngl/src/UniformSetters.cpp
+++ b/moderngl/src/UniformSetters.cpp
@@ -19,7 +19,11 @@ int MGLUniform_bool_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, &c_value);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -32,7 +36,11 @@ int MGLUniform_int_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, &c_value);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -45,7 +53,11 @@ int MGLUniform_uint_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, &c_value);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -58,7 +70,11 @@ int MGLUniform_float_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, &c_value);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
 
 	return 0;
 }
@@ -71,7 +87,11 @@ int MGLUniform_double_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, &c_value);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -84,7 +104,11 @@ int MGLUniform_sampler_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, &c_value);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, &c_value);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -119,7 +143,11 @@ int MGLUniform_bool_array_value_setter(MGLUniform * self, PyObject * value) {
 		}
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -151,7 +179,11 @@ int MGLUniform_int_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -183,7 +215,11 @@ int MGLUniform_uint_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -215,7 +251,11 @@ int MGLUniform_float_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -247,7 +287,11 @@ int MGLUniform_double_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size, c_values);
+	GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -279,7 +323,11 @@ int MGLUniform_sampler_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -314,7 +362,11 @@ int MGLUniform_bvec_value_setter(MGLUniform * self, PyObject * value) {
 		}
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -344,7 +396,11 @@ int MGLUniform_ivec_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -374,7 +430,11 @@ int MGLUniform_uvec_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -404,7 +464,11 @@ int MGLUniform_vec_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -434,7 +498,11 @@ int MGLUniform_dvec_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, 1, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -489,7 +557,11 @@ int MGLUniform_bvec_array_value_setter(MGLUniform * self, PyObject * value) {
 		}
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size * N, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -541,7 +613,11 @@ int MGLUniform_ivec_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size * N, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -593,7 +669,11 @@ int MGLUniform_uvec_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size * N, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -645,7 +725,11 @@ int MGLUniform_vec_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size * N, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -697,7 +781,11 @@ int MGLUniform_dvec_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size * N, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_vector_writer_proc)self->gl_value_writer_proc)(self->location, size * N, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;
@@ -728,7 +816,11 @@ int MGLUniform_matrix_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_matrix_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, 1, false, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_matrix_writer_proc)self->gl_value_writer_proc)(self->location, 1, false, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	return 0;
 }
@@ -779,7 +871,11 @@ int MGLUniform_matrix_array_value_setter(MGLUniform * self, PyObject * value) {
 		return -1;
 	}
 
-	((gl_uniform_matrix_writer_proc)self->gl_value_writer_proc)(self->program_obj, self->location, size, false, c_values);
+    GLint current_program;
+    ((gl_get_intergerv_proc) self->gl_get_integer_proc)(GL_CURRENT_PROGRAM, &current_program);
+    ((gl_use_program_proc)self->gl_use_program_prog)(self->program_obj);
+	((gl_uniform_matrix_writer_proc)self->gl_value_writer_proc)(self->location, size, false, c_values);
+    ((gl_use_program_proc)self->gl_use_program_prog)(current_program);
 
 	delete[] c_values;
 	return 0;


### PR DESCRIPTION
### Description

As per #438, the use of `glProgramUniformX` is unsupported by some strict 3.3 implementations. This PR is my (very naive) attempt at addressing the issue by replacing all calls to `glProgramUniform` by the following sequence:

```c
GLint current_program;
gl.GetIntegerv(GL_CURRENT_PROGRAM, &current_programm);
gl.UseProgram(self->program_obj);
gl.UniformX(...);
gl.UseProgram(current_program);
```

This version compiles but trashes the display.

**Edit**: the PR now appears to work with my cursory testing.