### PR TITLE
Remove reference to $DISPLAY variable

### DIFF
--- a/docs/the_guide/using-moderngl-in-ci.rst
+++ b/docs/the_guide/using-moderngl-in-ci.rst
@@ -108,7 +108,7 @@ _____
 
    .. code-block:: bash
     
-        sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
+        sudo /usr/bin/Xvfb :0 -screen 0 1280x1024x24 &
 
 3. You can run ModernGL now.
 
@@ -134,7 +134,7 @@ A example configuration for Github Actions:
           - name: Prepare
             run: |
                 sudo apt-get -y install xvfb
-                sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &            
+                sudo /usr/bin/Xvfb :0 -screen 0 1280x1024x24 &            
           - name: Test using ModernGL
             run: |
               python -m pip install -r requirements.txt


### PR DESCRIPTION
### Description

Updated the documentation to replace `$DISPLAY` with a working value, `:0`. Then there won't be missing bash variables when someone copy-and-pastes this code.

### List of changes

- removed reference to `$DISPLAY` in the CI configuration references.

<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
