### PR TITLE
C fixups

### DIFF
--- a/moderngl/src/Attribute.cpp
+++ b/moderngl/src/Attribute.cpp
@@ -61,7 +61,7 @@ void MGLAttribute_Invalidate(MGLAttribute * attribute) {
 
 	// TODO: decref
 
-	Py_TYPE(attribute) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(attribute, &MGLInvalidObject_Type);
 	Py_DECREF(attribute);
 }
 

--- a/moderngl/src/Buffer.cpp
+++ b/moderngl/src/Buffer.cpp
@@ -667,7 +667,7 @@ void MGLBuffer_Invalidate(MGLBuffer * buffer) {
 	const GLMethods & gl = buffer->context->gl;
 	gl.DeleteBuffers(1, (GLuint *)&buffer->buffer_obj);
 
-	Py_TYPE(buffer) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(buffer, &MGLInvalidObject_Type);
 	Py_DECREF(buffer->context);
 	Py_DECREF(buffer);
 }

--- a/moderngl/src/ComputeShader.cpp
+++ b/moderngl/src/ComputeShader.cpp
@@ -340,6 +340,6 @@ void MGLComputeShader_Invalidate(MGLComputeShader * compute_shader) {
 	gl.DeleteProgram(compute_shader->program_obj);
 
 	Py_DECREF(compute_shader->context);
-	Py_TYPE(compute_shader) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(compute_shader, &MGLInvalidObject_Type);
 	Py_DECREF(compute_shader);
 }

--- a/moderngl/src/Context.cpp
+++ b/moderngl/src/Context.cpp
@@ -1486,6 +1486,6 @@ void MGLContext_Invalidate(MGLContext * context) {
 
 	// TODO: decref
 
-	Py_TYPE(context) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(context, &MGLInvalidObject_Type);
 	Py_DECREF(context);
 }

--- a/moderngl/src/Error.cpp
+++ b/moderngl/src/Error.cpp
@@ -5,9 +5,13 @@
 void MGLError_SetTrace(const char * filename, const char * function, int line, const char * format, ...) {
 	// MGLError * error = (MGLError *)MGLError_tp_new(&MGLError_Type, 0, 0);
 
+	// Discard any old exception -- we'll raise a new one here.
+	// (todo: when PyErr_ChainExceptions is added to Python's API, use that
+	// to show both exceptions to the user.)
+	PyErr_Clear();
+
 	PyObject * moderngl = PyImport_ImportModule("moderngl");
 	if (!moderngl) {
-		PyErr_Clear();
 		return;
 	}
 
@@ -30,9 +34,11 @@ void MGLError_SetTrace(const char * filename, const char * function, int line, c
 void MGLError_SetTrace(const char * filename, const char * function, int line, PyObject * message) {
 	// MGLError * error = (MGLError *)MGLError_tp_new(&MGLError_Type, 0, 0);
 
+	// Discard any old exception -- we'll raise a new one here.
+	PyErr_Clear();
+
 	PyObject * moderngl = PyImport_ImportModule("moderngl");
 	if (!moderngl) {
-		PyErr_Clear();
 		return;
 	}
 

--- a/moderngl/src/Framebuffer.cpp
+++ b/moderngl/src/Framebuffer.cpp
@@ -1148,6 +1148,6 @@ void MGLFramebuffer_Invalidate(MGLFramebuffer * framebuffer) {
 		delete[] framebuffer->color_mask;
 	}
 
-	Py_TYPE(framebuffer) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(framebuffer, &MGLInvalidObject_Type);
 	Py_DECREF(framebuffer);
 }

--- a/moderngl/src/Program.cpp
+++ b/moderngl/src/Program.cpp
@@ -685,6 +685,6 @@ void MGLProgram_Invalidate(MGLProgram * program) {
 	const GLMethods & gl = program->context->gl;
 	gl.DeleteProgram(program->program_obj);
 
-	Py_TYPE(program) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(program, &MGLInvalidObject_Type);
 	Py_DECREF(program);
 }

--- a/moderngl/src/Python.hpp
+++ b/moderngl/src/Python.hpp
@@ -14,3 +14,7 @@ struct PyArrayInterface {
 	void * data;            // A pointer to the first element of the array
 	PyObject * descr;       // NULL or data-description (same as descr key of __array_interface__) -- must set ARR_HAS_DESCR flag or this will be ignored.
 };
+
+#if PY_VERSION_HEX < 0x03090000
+#define Py_SET_TYPE(obj, newtype) (Py_TYPE(obj) = (newtype))
+#endif

--- a/moderngl/src/Query.cpp
+++ b/moderngl/src/Query.cpp
@@ -267,6 +267,6 @@ void MGLQuery_Invalidate(MGLQuery * query) {
 	// TODO: release
 
 	Py_DECREF(query->context);
-	Py_TYPE(query) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(query, &MGLInvalidObject_Type);
 	Py_DECREF(query);
 }

--- a/moderngl/src/Renderbuffer.cpp
+++ b/moderngl/src/Renderbuffer.cpp
@@ -225,6 +225,6 @@ void MGLRenderbuffer_Invalidate(MGLRenderbuffer * renderbuffer) {
 	const GLMethods & gl = renderbuffer->context->gl;
 	gl.DeleteRenderbuffers(1, (GLuint *)&renderbuffer->renderbuffer_obj);
 
-	Py_TYPE(renderbuffer) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(renderbuffer, &MGLInvalidObject_Type);
 	Py_DECREF(renderbuffer);
 }

--- a/moderngl/src/Sampler.cpp
+++ b/moderngl/src/Sampler.cpp
@@ -350,7 +350,7 @@ void MGLSampler_Invalidate(MGLSampler * sampler) {
 	const GLMethods & gl = sampler->context->gl;
 	gl.DeleteSamplers(1, (GLuint *)&sampler->sampler_obj);
 
-	Py_TYPE(sampler) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(sampler, &MGLInvalidObject_Type);
 	Py_DECREF(sampler);
 	Py_DECREF(sampler->context);
 }

--- a/moderngl/src/Scope.cpp
+++ b/moderngl/src/Scope.cpp
@@ -331,6 +331,6 @@ void MGLScope_Invalidate(MGLScope * scope) {
 	Py_DECREF(scope->old_framebuffer);
 
 	Py_DECREF(scope->context);
-	Py_TYPE(scope) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(scope, &MGLInvalidObject_Type);
 	Py_DECREF(scope);
 }

--- a/moderngl/src/Texture.cpp
+++ b/moderngl/src/Texture.cpp
@@ -992,6 +992,6 @@ void MGLTexture_Invalidate(MGLTexture * texture) {
 	gl.DeleteTextures(1, (GLuint *)&texture->texture_obj);
 
 	Py_DECREF(texture->context);
-	Py_TYPE(texture) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(texture, &MGLInvalidObject_Type);
 	Py_DECREF(texture);
 }

--- a/moderngl/src/Texture3D.cpp
+++ b/moderngl/src/Texture3D.cpp
@@ -696,6 +696,6 @@ void MGLTexture3D_Invalidate(MGLTexture3D * texture) {
 	gl.DeleteTextures(1, (GLuint *)&texture->texture_obj);
 
 	Py_DECREF(texture->context);
-	Py_TYPE(texture) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(texture, &MGLInvalidObject_Type);
 	Py_DECREF(texture);
 }

--- a/moderngl/src/TextureArray.cpp
+++ b/moderngl/src/TextureArray.cpp
@@ -710,6 +710,6 @@ void MGLTextureArray_Invalidate(MGLTextureArray * texture) {
 	gl.DeleteTextures(1, (GLuint *)&texture->texture_obj);
 
 	Py_DECREF(texture->context);
-	Py_TYPE(texture) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(texture, &MGLInvalidObject_Type);
 	Py_DECREF(texture);
 }

--- a/moderngl/src/TextureCube.cpp
+++ b/moderngl/src/TextureCube.cpp
@@ -626,6 +626,6 @@ void MGLTextureCube_Invalidate(MGLTextureCube * texture) {
 	const GLMethods & gl = texture->context->gl;
 	gl.DeleteTextures(1, (GLuint *)&texture->texture_obj);
 
-	Py_TYPE(texture) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(texture, &MGLInvalidObject_Type);
 	Py_DECREF(texture);
 }

--- a/moderngl/src/Uniform.cpp
+++ b/moderngl/src/Uniform.cpp
@@ -109,7 +109,7 @@ void MGLUniform_Invalidate(MGLUniform * uniform) {
 
 	// TODO: decref
 
-	Py_TYPE(uniform) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(uniform, &MGLInvalidObject_Type);
 	Py_DECREF(uniform);
 }
 

--- a/moderngl/src/VertexArray.cpp
+++ b/moderngl/src/VertexArray.cpp
@@ -707,7 +707,7 @@ void MGLVertexArray_Invalidate(MGLVertexArray * array) {
 	const GLMethods & gl = array->context->gl;
 	gl.DeleteVertexArrays(1, (GLuint *)&array->vertex_array_obj);
 
-	Py_TYPE(array) = &MGLInvalidObject_Type;
+	Py_SET_TYPE(array, &MGLInvalidObject_Type);
 	Py_DECREF(array->program);
 	Py_XDECREF(array->index_buffer);
 	Py_DECREF(array);


### PR DESCRIPTION
Here are issues I found when trying moderngl with Python 3.10 and 3.11-dev.


### Use Py_SET_TYPE

In Python 3.11a0dev (main branch), Py_TYPE is a function instead
of a macro, which means it cannot be assigned to.
For assignments, Py_SET_TYPE should be used. That was only added
in Python 3.9, but for older versions we can use a simple macro.

It's possible that this change will be reverted before Python 3.11
is released, but still, assigning to Py_TYPE is deprecated.

###  Fix error handling in `MGLError_SetTrace`

(This turned a error in my code into a fatal crash, making it hard to debug.)

When `MGLError_SetTrace` was called with an active exception
(such as from `MGLFramebuffer_set_scissor` after passing a
non-int element), `PyImport_ImportModule` was called with an
exception set.
The effect on the import machinery is unpredictable: generally
the first check of `PyErr_Occurred` (rather than of the C return
value) will assume a function failed.
In Python 3.10 this leads to a fatal crash.

Clear the old exception *first* since we replace it with a new one.
(The super-proper way to do this would be exception chaining,
"During handling of the above exception, another exception occurred".
The current C API for that is complicated, but there are [plans to fix that](https://github.com/python/cpython/pull/27799))

