### PR TITLE
Copy all multisampled color attachments

### DIFF
--- a/moderngl/src/Context.cpp
+++ b/moderngl/src/Context.cpp
@@ -288,6 +288,7 @@ PyObject * MGLContext_copy_framebuffer(MGLContext * self, PyObject * args) {
 		{
 			gl.ReadBuffer(src->draw_buffers[i]);
 			gl.DrawBuffer(dst_framebuffer->draw_buffers[i]);
+
 			gl.BlitFramebuffer(
 				0, 0, width, height,
 				0, 0, width, height,
@@ -298,6 +299,7 @@ PyObject * MGLContext_copy_framebuffer(MGLContext * self, PyObject * args) {
 		gl.BindFramebuffer(GL_FRAMEBUFFER, self->bound_framebuffer->framebuffer_obj);
 		gl.ReadBuffer(prev_read_buffer);
 		gl.DrawBuffer(prev_draw_buffer);
+		gl.DrawBuffers(self->bound_framebuffer->draw_buffers_len, self->bound_framebuffer->draw_buffers);
 
 	} else if (Py_TYPE(dst) == &MGLTexture_Type) {
 

--- a/moderngl/src/Context.cpp
+++ b/moderngl/src/Context.cpp
@@ -269,15 +269,35 @@ PyObject * MGLContext_copy_framebuffer(MGLContext * self, PyObject * args) {
 			height = src->height < dst_framebuffer->height ? src->height : dst_framebuffer->height;
 		}
 
-		gl.BindFramebuffer(GL_READ_FRAMEBUFFER, src->framebuffer_obj);
-		gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, dst_framebuffer->framebuffer_obj);
-		gl.BlitFramebuffer(
-			0, 0, width, height,
-			0, 0, width, height,
-			GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT,
-			GL_NEAREST
-		);
+		if (dst_framebuffer->draw_buffers_len != src->draw_buffers_len)
+		{
+			MGLError_Set("Destination and source framebuffers have different number of color attachments!");
+			return 0;
+		}
+
+		int prev_read_buffer = -1;
+		int prev_draw_buffer = -1;
+		gl.GetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
+		gl.GetIntegerv(GL_DRAW_BUFFER, &prev_draw_buffer);
+
+		int color_attachment_len = dst_framebuffer->draw_buffers_len;
+		for (int i = 0; i < color_attachment_len; ++i)
+		{
+			gl.ReadBuffer(src->draw_buffers[i]);
+			gl.DrawBuffer(dst_framebuffer->draw_buffers[i]);
+
+			gl.BindFramebuffer(GL_READ_FRAMEBUFFER, src->framebuffer_obj);
+			gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, dst_framebuffer->framebuffer_obj);
+			gl.BlitFramebuffer(
+				0, 0, width, height,
+				0, 0, width, height,
+				GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT,
+				GL_NEAREST
+			);
+		}
 		gl.BindFramebuffer(GL_FRAMEBUFFER, self->bound_framebuffer->framebuffer_obj);
+		gl.ReadBuffer(prev_read_buffer);
+		gl.DrawBuffer(prev_draw_buffer);
 
 	} else if (Py_TYPE(dst) == &MGLTexture_Type) {
 

--- a/moderngl/src/Context.cpp
+++ b/moderngl/src/Context.cpp
@@ -275,19 +275,19 @@ PyObject * MGLContext_copy_framebuffer(MGLContext * self, PyObject * args) {
 			return 0;
 		}
 
+
 		int prev_read_buffer = -1;
 		int prev_draw_buffer = -1;
+		int color_attachment_len = dst_framebuffer->draw_buffers_len;
 		gl.GetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
 		gl.GetIntegerv(GL_DRAW_BUFFER, &prev_draw_buffer);
+		gl.BindFramebuffer(GL_READ_FRAMEBUFFER, src->framebuffer_obj);
+		gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, dst_framebuffer->framebuffer_obj);
 
-		int color_attachment_len = dst_framebuffer->draw_buffers_len;
 		for (int i = 0; i < color_attachment_len; ++i)
 		{
 			gl.ReadBuffer(src->draw_buffers[i]);
 			gl.DrawBuffer(dst_framebuffer->draw_buffers[i]);
-
-			gl.BindFramebuffer(GL_READ_FRAMEBUFFER, src->framebuffer_obj);
-			gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, dst_framebuffer->framebuffer_obj);
 			gl.BlitFramebuffer(
 				0, 0, width, height,
 				0, 0, width, height,


### PR DESCRIPTION
### Description

This PR is modifying the way `Context.copy_framebuffer` method operates when copying from mutisampled FBO with multiple color attachments into a non-multisampled FBO with multiple color attachment. 

Such functionality is needed when user wants to read out multiple color attachments from a multisampled FBO to the CPU memory.

Previously, only the first color attachments (`GL_COLOR_ATTACHMENT0`) was copied, while others have been ignored.

This PR addresses the [issue #447](https://github.com/moderngl/moderngl/issues/447) 

### List of changes

- **changed** `moderngl/src/Context.cpp`. Code first checks whether the source and destination buffers have the same number of color attachments. If so, the current state of `GL_READ_BUFFER` and `GL_DRAW_BUFFER` is recorded. Next, the code loops over the `draw_buffers` member of `MGLFramebuffer` objects, and uses `glReadBuffer` \ `glDrawBuffer` calls to set the targets for `glBlitFramebuffer` operation. Finally, the code restores the previous state of `GL_READ_BUFFER` and `GL_DRAW_BUFFER` in order to avoid any side effects.

### Example program:
On the main branch, this program shows one image of red triangle and two empty images.
With the propsed changes, the programs shows shows images of red, green and blue triangles, as expected.
```py
import moderngl
import numpy as np
from PIL import Image
from PIL.Image import Transpose


def multisampled_mrt():
    with moderngl.create_context(
        require=330,
        standalone=True,
        backend="egl",
    ) as ctx:
        # Init the shader program
        prog = ctx.program(
            vertex_shader="""
                #version 330
                in vec2 in_vert;

                void main() {
                    gl_Position = vec4(in_vert, 0.0, 1.0);
                }
            """,
            fragment_shader="""
                #version 330
                
                in vec3 v_color;
                
                layout(location=0) out vec4 f_color_r;
                layout(location=1) out vec4 f_color_g;
                layout(location=2) out vec4 f_color_b;

                void main() {
                    f_color_r = vec4(1.0, 0.0, 0.0, 1.0);
                    f_color_g = vec4(0.0, 1.0, 0.0, 1.0);
                    f_color_b = vec4(0.0, 0.0, 1.0, 1.0);
                }
            """,
        )
        resolution = (800, 600)

        # Create multisampled framebuffer with multiple color attachments
        color_r_texture = ctx.texture(resolution, components=4, dtype="f1", samples=4)
        color_g_texture = ctx.texture(resolution, components=4, dtype="f1", samples=4)
        color_b_texture = ctx.texture(resolution, components=4, dtype="f1", samples=4)

        fbo = ctx.framebuffer(
            (color_r_texture, color_g_texture, color_b_texture),
            ctx.depth_renderbuffer(resolution, samples=4),
        )

        # Create VAO
        vertices = np.array(
            [0.0, 0.8, -0.6, -0.8, 0.6, -0.8],  # x, y
            dtype="f4",
        )

        vbo = ctx.buffer(vertices)

        vao = ctx.vertex_array(prog, [(vbo, "2f", "in_vert")])

        # Render to offscreen, multisampled framebuffer

        fbo.use()
        fbo.clear(color=(0.0, 0.0, 0.0, 1.0))
        vao.render()

        # Create "Resolve" framebuffer to which we copy multisampled framebuffer
        color_r_resolve = ctx.texture(resolution, components=4, dtype="f1", samples=0)
        color_g_resolve = ctx.texture(resolution, components=4, dtype="f1", samples=0)
        color_b_resolve = ctx.texture(resolution, components=4, dtype="f1", samples=0)
        resolve_fbo = ctx.framebuffer(
            (color_r_resolve, color_g_resolve, color_b_resolve),
            ctx.depth_renderbuffer(resolution, samples=0),
        )

        # Perform the copy
        ctx.copy_framebuffer(resolve_fbo, fbo)

        # Read images out
        img_red = np.frombuffer(
            resolve_fbo.read(components=4, attachment=0), dtype=np.uint8
        ).reshape((resolution[1], resolution[0], 4))
        img_green = np.frombuffer(
            resolve_fbo.read(components=4, attachment=1), dtype=np.uint8
        ).reshape((resolution[1], resolution[0], 4))
        img_blue = np.frombuffer(
            resolve_fbo.read(components=4, attachment=2), dtype=np.uint8
        ).reshape((resolution[1], resolution[0], 4))

        # Display images
        Image.fromarray(img_red).transpose(Transpose.FLIP_TOP_BOTTOM).show()
        Image.fromarray(img_green).transpose(Transpose.FLIP_TOP_BOTTOM).show()
        Image.fromarray(img_blue).transpose(Transpose.FLIP_TOP_BOTTOM).show()


if __name__ == "__main__":
    multisampled_mrt()
```
