### PR TITLE
Remove redundant code from example

### DIFF
--- a/examples/ported/_example.py
+++ b/examples/ported/_example.py
@@ -11,10 +11,3 @@ class Example(mglw.WindowConfig):
     resizable = True
 
     resource_dir = os.path.normpath(os.path.join(__file__, '../../data'))
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    @classmethod
-    def run(cls):
-        mglw.run_window_config(cls)


### PR DESCRIPTION
Removed two functions that are the same as the functions they override