### PR TITLE
Fix a few typos

### DIFF
--- a/docs/install/installation.rst
+++ b/docs/install/installation.rst
@@ -61,8 +61,8 @@ this method, to make Moderngl work.
 
 There are essentially two ways,
 
-* Compling Mesa yourselves see https://docs.mesa3d.org/install.html.
-* Using msys2, which provids pre-compiled Mesa binaries.
+* Compiling Mesa yourselves see https://docs.mesa3d.org/install.html.
+* Using msys2, which provides pre-compiled Mesa binaries.
 
 Using MSYS2
 ___________

--- a/docs/install/using-moderngl-in-ci.rst
+++ b/docs/install/using-moderngl-in-ci.rst
@@ -128,5 +128,5 @@ A example configuration for Github Actions:
 macOS
 -----
 
-You won't need any specialy configuration to run on macOS.
+You won't need any special configuration to run on macOS.
 

--- a/docs/topics/buffer_format.rst
+++ b/docs/topics/buffer_format.rst
@@ -198,7 +198,7 @@ padding for alignment:
 |       |       | byte     | byte     | byte     |         |
 +-------+-------+----------+----------+----------+---------+
 
-Such a buffer, however you choose to contruct it, would then be passed into
+Such a buffer, however you choose to construct it, would then be passed into
 a VAO using::
 
     vao = ctx.vertex_array(
@@ -254,7 +254,7 @@ call::
     )
 
 So, the vertices and normals, using ``/v``, are passed to each vertex within
-an instance. This fulfills the rule tha the first VBO in a VAO must have usage
+an instance. This fulfills the rule that the first VBO in a VAO must have usage
 ``/v``. These are passed to vertex attributes as::
 
     in vec3 in_vert;

--- a/docs/topics/texture_formats.rst
+++ b/docs/topics/texture_formats.rst
@@ -45,7 +45,7 @@ Float Textures
 The ``f1`` texture is the most commonly used textures in OpenGL
 and is currently the default. Each component takes 1 byte (4 bytes for RGBA).
 This is not really a "real" float format, but a shader will read
-normalized values from these textures. ``0-255`` (byte rage) is read
+normalized values from these textures. ``0-255`` (byte range) is read
 as a value from ``0.0`` to ``1.0`` in shaders.
 
 In shaders the sampler type should be ``sampler2D``, ``sampler2DArray``

--- a/examples/basic_colors_and_texture.py
+++ b/examples/basic_colors_and_texture.py
@@ -67,7 +67,7 @@ class ColorsAndTexture(Example):
         self.use_texture = self.prog['UseTexture']
 
         # Note: This is a fairly manual way to loading and rendering wavefront files.
-        # There are easier ways when loading mutiple objects in a single obj file.
+        # There are easier ways when loading multiple objects in a single obj file.
 
         # Load obj files
         self.scene_ground = self.load_scene('scene-1-ground.obj')

--- a/examples/basic_empty_window.py
+++ b/examples/basic_empty_window.py
@@ -78,7 +78,7 @@ class EmptyWindow(Example):
             if key == keys.C:
                 self.wnd.cursor = not self.wnd.cursor
 
-            # Shuffle window tittle
+            # Shuffle window title
             if key == keys.T:
                 title = list(self.wnd.title)
                 random.shuffle(title)

--- a/examples/basic_simple_color_triangle.py
+++ b/examples/basic_simple_color_triangle.py
@@ -1,5 +1,5 @@
 '''
-    Renders a traingle that has all RGB combinations
+    Renders a triangle that has all RGB combinations
 '''
 
 import numpy as np

--- a/examples/conways_game_of_life.py
+++ b/examples/conways_game_of_life.py
@@ -2,7 +2,7 @@
 A Game of Life implementation using transform feedback.
 
 We calculate the next state of the map with transform()
-meaning a vertex shader will geneate the new state into a buffer.
+meaning a vertex shader will generate the new state into a buffer.
 This buffer is then written into the texture we display.
 This is a fast vram to vram copy.
 

--- a/examples/geometry_shader_sprites.py
+++ b/examples/geometry_shader_sprites.py
@@ -3,7 +3,7 @@ Quick and dirty example showing how sprites can be rendered using a geometry sha
 We also show simple scrolling with projection matrix.
 
 The goal is to redice the sprite data on the client as much as possible.
-We can define a sprite by its postion, size and rotation. This can be
+We can define a sprite by its position, size and rotation. This can be
 expressed in 5 32 bit floats. This also opens up for individually rotating
 each sprite in the shader itself. This technique can be extended with more
 sprite parameters.
@@ -160,7 +160,7 @@ class GeoSprites(Example):
 
         self.sprite_data.write(array("f", gen_sprites(time)))
 
-        # calculate scroll offsets. We truncate to intergers here.
+        # calculate scroll offsets. We truncate to integers here.
         # This depends what "look" you want for your game.
         scroll_x, scroll_y = int(math.sin(time) * 100), int(math.cos(time) * 100)
 

--- a/examples/integration_skia_wxpython.py
+++ b/examples/integration_skia_wxpython.py
@@ -37,7 +37,7 @@ class DrawCanvas(glcanvas.GLCanvas):
             self.ctx.set_viewport(0, 0, self.Size.width, self.Size.height)
 
     def InitGL(self):
-        # Initilize the skia context with the moderngl context
+        # Initialize the skia context with the moderngl context
         self.ctx = moderngl.create_context()
         context = skia.GrDirectContext.MakeGL()
         backend_render_target = skia.GrBackendRenderTarget(

--- a/examples/shadowmapping.py
+++ b/examples/shadowmapping.py
@@ -188,7 +188,7 @@ class ShadowMappingSample(Example):
             target=(0, 0, 0),
             up=(0.0, 0.0, 1.0),
         )
-        # light projection matrix (scene dependant)
+        # light projection matrix (scene dependent)
         light_proj = Matrix44.perspective_projection(
             fovy=90.0 / 4,  # smaller value increase shadow precision
             aspect=self.wnd.aspect_ratio,

--- a/examples/tesselation.py
+++ b/examples/tesselation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-'''Simple example of using tesselation to render a cubic Bézier curve'''
+'''Simple example of using tessellation to render a cubic Bézier curve'''
 
 import numpy as np
 
@@ -28,7 +28,7 @@ class Tessellation(Example):
             layout(vertices = 4) out;
 
             void main() {
-            // set tesselation levels, TODO compute dynamically
+            // set tessellation levels, TODO compute dynamically
             gl_TessLevelOuter[0] = 1;
             gl_TessLevelOuter[1] = 32;
 

--- a/examples/transform_feedback_changing_primitive.py
+++ b/examples/transform_feedback_changing_primitive.py
@@ -34,7 +34,7 @@ class GenerateData(Example):
             ''',
         )
 
-        # Tranform program with geo shader
+        # Transform program with geo shader
         self.transform_prog = self.ctx.program(
             vertex_shader='''
                 #version 330

--- a/examples/transform_feedback_gen_buffer.py
+++ b/examples/transform_feedback_gen_buffer.py
@@ -1,6 +1,6 @@
 """
 Generates buffer data on the gpu using transform feedback.
-We use an empty VertexArray running it vertices times outputing data to the buffer.
+We use an empty VertexArray running it vertices times outputting data to the buffer.
 
 More fancy calculations can of course be done. This example just shows the concept.
 """

--- a/examples/transform_feedback_multiple_buffers.py
+++ b/examples/transform_feedback_multiple_buffers.py
@@ -1,6 +1,6 @@
 """
 Generates buffer data on the gpu using transform feedback.
-We use an empty VertexArray running it vertices times outputing data to the buffer.
+We use an empty VertexArray running it vertices times outputting data to the buffer.
 
 More fancy calculations can of course be done. This example just shows the concept.
 """


### PR DESCRIPTION
### Description

I was looking at the ModernGL docs and noticed it said "byte rage" instead of "byte range." I thought that if I was going to make a PR anyway, I might as well see if I can find other typos, so I used `codespell` to span the code for typos.

`codespell` reports a few more typos in actual source files, but I wanted this to be a simple PR so I didn't want to touch any actual source code.

### List of changes

- **edited** docs/ and examples/ to fix typos