### PR TITLE
Introspect storage blocks #540

### DIFF
--- a/_moderngl.py
+++ b/_moderngl.py
@@ -118,6 +118,38 @@ class UniformBlock:
         self.ctx._set_ubo_binding(self.program_obj, self.index, value)
 
 
+class StorageBlock:
+    def __init__(self):
+        self.program_obj = None
+        self.index = None
+        self.name = None
+        self.ctx = None
+        self.extra = None
+
+    def __repr__(self):
+        return f'<StorageBlock: {self.index}>'
+
+    @property
+    def mglo(self):
+        return self
+
+    @property
+    def binding(self):
+        return self.ctx._get_storage_block_binding(self.program_obj, self.index)
+
+    @binding.setter
+    def binding(self, binding):
+        self.ctx._set_storage_block_binding(self.program_obj, self.index, binding)
+
+    @property
+    def value(self):
+        return self.ctx._get_storage_block_binding(self.program_obj, self.index)
+
+    @value.setter
+    def value(self, value):
+        self.ctx._set_storage_block_binding(self.program_obj, self.index, value)
+
+
 class Subroutine:
     def __init__(self):
         self.index = None
@@ -297,6 +329,15 @@ def make_uniform_block(name, program_obj, index, size, ctx):
     res.program_obj = program_obj
     res.index = index
     res.size = size
+    res.ctx = ctx
+    return res
+
+
+def make_storage_block(name, program_obj, index, ctx):
+    res = StorageBlock()
+    res.name = name
+    res.program_obj = program_obj
+    res.index = index
     res.ctx = ctx
     return res
 

--- a/docs/reference/program.rst
+++ b/docs/reference/program.rst
@@ -93,3 +93,4 @@ Program Members
     subroutine.rst
     attribute.rst
     varying.rst
+    storage_block.rst

--- a/docs/reference/storage_block.rst
+++ b/docs/reference/storage_block.rst
@@ -1,0 +1,17 @@
+
+StorageBlock
+============
+
+.. py:currentmodule:: moderngl
+
+.. autoclass:: moderngl.StorageBlock
+
+.. autoattribute:: StorageBlock.binding
+.. autoattribute:: StorageBlock.value
+.. autoattribute:: StorageBlock.name
+.. autoattribute:: StorageBlock.index
+.. autoattribute:: StorageBlock.extra
+.. autoattribute:: StorageBlock.mglo
+
+.. toctree::
+    :maxdepth: 2

--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -574,6 +574,42 @@ class UniformBlock:
     '''
 
 
+class StorageBlock:
+    '''
+    Storage Block metadata
+    '''
+
+    binding: int
+    '''
+    int: The binding of the storage block
+    '''
+
+    value: int
+    '''
+    int: The value of the storage block.
+    '''
+
+    name: str
+    '''
+    str: The name of the storage block.
+    '''
+
+    index: int
+    '''
+    int: The index of the storage block.
+    '''
+
+    extra: Any
+    '''
+    Attribute for storing user defined objects
+    '''
+
+    mglo: Any
+    '''
+    Internal moderngl core object
+    '''
+
+
 class Subroutine:
     '''
     This class represents a program subroutine.

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -2,7 +2,7 @@ import warnings
 from collections import deque
 from typing import Any, Deque, Dict, Generator, List, Optional, Set, Tuple, Union
 
-from _moderngl import Attribute, Error, InvalidObject, Subroutine, Uniform, UniformBlock, Varying  # noqa
+from _moderngl import Attribute, Error, InvalidObject, Subroutine, Uniform, UniformBlock, Varying, StorageBlock  # noqa
 
 try:
     from moderngl import mgl  # type: ignore

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -1551,9 +1551,11 @@ PyObject * MGLContext_compute_shader(MGLContext * self, PyObject * args) {
 
     int num_uniforms = 0;
     int num_uniform_blocks = 0;
+    int num_storage_blocks = 0;
 
     gl.GetProgramiv(program_obj, GL_ACTIVE_UNIFORMS, &num_uniforms);
     gl.GetProgramiv(program_obj, GL_ACTIVE_UNIFORM_BLOCKS, &num_uniform_blocks);
+    gl.GetProgramInterfaceiv(program_obj, GL_SHADER_STORAGE_BLOCK, GL_ACTIVE_RESOURCES, &num_storage_blocks);
 
     PyObject * members_dict = PyDict_New();
 
@@ -1595,6 +1597,23 @@ PyObject * MGLContext_compute_shader(MGLContext * self, PyObject * args) {
         PyObject * item = PyObject_CallMethod(
             helper, "make_uniform_block", "(siiiO)",
             name, program_obj, index, size, self
+        );
+
+        PyDict_SetItemString(members_dict, name, item);
+        Py_DECREF(item);
+    }
+
+    for(int i = 0; i < num_storage_blocks; ++i) {
+        int size = 0;
+        int name_len = 0;
+        char name[256];
+
+        gl.GetProgramResourceName(program_obj, GL_SHADER_STORAGE_BLOCK, i, 256, &name_len, name);
+        clean_glsl_name(name, name_len);
+
+        PyObject * item = PyObject_CallMethod(
+            helper, "make_storage_block", "(siiO)",
+            name, program_obj, i, self
         );
 
         PyDict_SetItemString(members_dict, name, item);
@@ -8295,6 +8314,30 @@ PyObject * MGLContext_set_ubo_binding(MGLContext * self, PyObject * args) {
     Py_RETURN_NONE;
 }
 
+PyObject * MGLContext_get_storage_block_binding(MGLContext * self, PyObject * args) {
+    int program_obj;
+    int index;
+    if (!PyArg_ParseTuple(args, "II", &program_obj, &index)) {
+        return NULL;
+    }
+    int binding = 0;
+    GLenum prop = GL_BUFFER_BINDING;
+    self->gl.GetProgramResourceiv(program_obj, GL_SHADER_STORAGE_BLOCK, index, 1, &prop, 1, NULL, &binding);
+    return PyLong_FromLong(binding);
+}
+
+PyObject * MGLContext_set_storage_block_binding(MGLContext * self, PyObject * args) {
+    int program_obj;
+    int index;
+    int binding;
+    if (!PyArg_ParseTuple(args, "III", &program_obj, &index, &binding)) {
+        return NULL;
+    }
+    self->gl.ShaderStorageBlockBinding(program_obj, index, binding);
+    Py_RETURN_NONE;
+}
+
+
 PyObject * MGLContext_read_uniform(MGLContext * self, PyObject * args) {
     int program_obj;
     int location;
@@ -9391,6 +9434,8 @@ PyMethodDef MGLContext_methods[] = {
 
     {(char *)"_get_ubo_binding", (PyCFunction)MGLContext_get_ubo_binding, METH_VARARGS},
     {(char *)"_set_ubo_binding", (PyCFunction)MGLContext_set_ubo_binding, METH_VARARGS},
+    {(char *)"_get_storage_block_binding", (PyCFunction)MGLContext_get_storage_block_binding, METH_VARARGS},
+    {(char *)"_set_storage_block_binding", (PyCFunction)MGLContext_set_storage_block_binding, METH_VARARGS},
     {(char *)"_write_uniform", (PyCFunction)MGLContext_write_uniform, METH_VARARGS},
     {(char *)"_read_uniform", (PyCFunction)MGLContext_read_uniform, METH_VARARGS},
     {},

--- a/tests/test_simple_compute_shader.py
+++ b/tests/test_simple_compute_shader.py
@@ -55,5 +55,5 @@ def test_compute_shader(ctx):
     compute_shader.run()
     assert compute_shader.get('multiplier', None) is not None
     assert compute_shader == compute_shader
-    assert [i for i in compute_shader] == ['multiplier']
+    assert [i for i in compute_shader] == ['multiplier', 'something_in', 'something_out']
     compute_shader.release()


### PR DESCRIPTION
Quick and dirty introspection of storage blocks. It works, but needs to look through it.

I do wonder if we should move program introspection to a function in the context so we can reuse code between program and compute shader. Just need to check version code and skip the ssbo part?