### PR TITLE
fix: remove warnings unused variables from build extension

### DIFF
--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -1604,7 +1604,6 @@ PyObject * MGLContext_compute_shader(MGLContext * self, PyObject * args) {
     }
 
     for(int i = 0; i < num_storage_blocks; ++i) {
-        int size = 0;
         int name_len = 0;
         char name[256];
 
@@ -3157,7 +3156,6 @@ PyObject * MGLContext_program(MGLContext * self, PyObject * args) {
     gl.GetProgramiv(program->program_obj, GL_ACTIVE_UNIFORMS, &num_uniforms);
     gl.GetProgramiv(program->program_obj, GL_ACTIVE_UNIFORM_BLOCKS, &num_uniform_blocks);
 
-    int num_subroutines = num_vertex_shader_subroutines + num_fragment_shader_subroutines + num_geometry_shader_subroutines + num_tess_evaluation_shader_subroutines + num_tess_control_shader_subroutines;
     int num_subroutine_uniforms = num_vertex_shader_subroutine_uniforms + num_fragment_shader_subroutine_uniforms + num_geometry_shader_subroutine_uniforms + num_tess_evaluation_shader_subroutine_uniforms + num_tess_control_shader_subroutine_uniforms;
 
     program->num_vertex_shader_subroutines = num_vertex_shader_subroutine_uniforms;


### PR DESCRIPTION
### Description

Some warnings -> unused variable appears at build extension stage from the latest master branch :
```shell
~]$ python setup.py build_ext --inplace


running build_ext
building 'moderngl.mgl' extension
creating build/temp.linux-x86_64-3.8/src
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPY_SSIZE_T_CLEAN -I$HOME/Prog/moderngl/env/include -I$HOME/.pyenv/versions/3.8.9/include/python3.8 -c src/modern
gl.cpp -o build/temp.linux-x86_64-3.8/src/moderngl.o -fpermissive
src/moderngl.cpp: In function ‘PyObject* MGLContext_compute_shader(MGLContext*, PyObject*)’:
src/moderngl.cpp:1607:13: warning: unused variable ‘size’ [-Wunused-variable]
 1607 |         int size = 0;
      |             ^~~~
src/moderngl.cpp: In function ‘PyObject* MGLContext_program(MGLContext*, PyObject*)’:
src/moderngl.cpp:3160:9: warning: unused variable ‘num_subroutines’ [-Wunused-variable]
 3160 |     int num_subroutines = num_vertex_shader_subroutines + num_fragment_shader_subroutines + num_geometry_shader_subroutines + num_tess_evaluation_shader_subroutines + num_tess_control_shader_subroutines;
      |         ^~~~~~~~~~~~~~~
g++ -pthread -shared -L$HOME/.pyenv/versions/3.8.9/lib -L$HOME/.pyenv/versions/3.8.9/lib build/temp.linux-x86_64-3.8/src/moderngl.o -o build/lib.linux-x86_64-3.8/moderngl/mgl.cpython-38-x86_64-linux-gnu.s
o
copying build/lib.linux-x86_64-3.8/moderngl/mgl.cpython-38-x86_64-linux-gnu.so -> moderngl
```

### List of changes

- **fixed** : just remove unused variables incriminated
<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
