### PR TITLE
Reactivate UTests for External Texture

### DIFF
--- a/tests/test_texture_external.py
+++ b/tests/test_texture_external.py
@@ -1,27 +1,27 @@
 
 
-def test_1(ctx):
-    tex = ctx.texture((5, 10), 4)
-    ext = ctx.external_texture(
-        glo=tex.glo,
+def test_init_from_texture_and_params(ctx):
+    params_tex = dict(
         size=(5, 10),
         components=4,
         samples=0,
-        dtype="f1",
+        dtype="f1"
     )
-    ext.size == (5, 10)
-    ext.width == 5
-    ext.height == 10
-    ext.components == 4
-    ext.glo == tex.glo
-    ext.dtype == "f1"
-    ext.samples == 0
-    ext.repeat_x is True
-    ext.repeat_y is True
-    ext.filter == (ctx.LINEAR, ctx.LINEAR)
-    ext.swizzle == "RGBA"
-    ext.depth is False
-    ext.anisotropy == 1.0
-    ext.mglo != tex.mglo
-    ext.ctx = ctx
-    ext.extra == {}
+    tex = ctx.texture(params_tex["size"], params_tex["components"])
+    ext = ctx.external_texture(**{**params_tex, **dict(glo=tex.glo)})
+    assert ext.size == params_tex["size"]
+    assert ext.width == params_tex["size"][0]
+    assert ext.height == params_tex["size"][1]
+    assert ext.components == params_tex["components"]
+    assert ext.glo == tex.glo
+    assert ext.dtype == params_tex["dtype"]
+    assert ext.samples == params_tex["samples"]
+    assert ext.repeat_x is True
+    assert ext.repeat_y is True
+    assert ext.filter == (ctx.LINEAR, ctx.LINEAR)
+    assert ext.swizzle == "RGBA"
+    assert ext.depth is False
+    assert ext.anisotropy == 0.0
+    assert ext.mglo != tex.mglo
+    assert ext.ctx == ctx
+    assert ext.extra == None


### PR DESCRIPTION
### Description

Reactivate (and fix) some unit tests for external texture

### List of changes

- **fixed** : reactivate/fix (py)tests on `test_texture_external`
<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
