### PR TITLE
docs: Change "do" to "does" in intro header

### DIFF
--- a/docs/the_guide/intro.rst
+++ b/docs/the_guide/intro.rst
@@ -79,7 +79,7 @@ learning 3.3+ shaders and understanding the rendering pipeline
 will greatly help you understand `Vulkan`_. In most cases you can
 pretty much copy paste the shaders over to `Vulkan`_.
 
-Where do ModernGL fit into all this?
+Where does ModernGL fit into all this?
 ------------------------------------
 
 The ModernGL library exposes the **Programmable Pipeline**

--- a/docs/the_guide/intro.rst
+++ b/docs/the_guide/intro.rst
@@ -80,7 +80,7 @@ will greatly help you understand `Vulkan`_. In most cases you can
 pretty much copy paste the shaders over to `Vulkan`_.
 
 Where does ModernGL fit into all this?
-------------------------------------
+--------------------------------------
 
 The ModernGL library exposes the **Programmable Pipeline**
 using OpenGL 3.3 core or higher. However, we don't expose OpenGL


### PR DESCRIPTION
### Description

Correct me if I am wrong, but would "does" make more sense here?
I am following the tutorials but thought I'd fix this as I went.

### List of changes

- **added** ...
- **removed** ...
- **fixed** ...
- **changed** ...

<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
