### PR TITLE
docs: Remove extra tick-mark in Basics guide

### DIFF
--- a/docs/the_guide/basic.rst
+++ b/docs/the_guide/basic.rst
@@ -101,7 +101,7 @@ Each type above also has a 2, 3 and 4 component version::
 More about GLSL `data types`_ can be found in the Khronos wiki.
 
 The available functions are for example: ``radians``, ``degrees``
-``sin``, ```cos``, ``tan``, ``asin``, ``acos``, ``atan``, ``pow``
+``sin``, ``cos``, ``tan``, ``asin``, ``acos``, ``atan``, ``pow``
 ``exp``, ``log``, ``exp2``, ``log2``, ``sqrt``, ``inversesqrt``,
 ``abs``, ``sign``, ``floor``, ``ceil``, ``fract``, ``mod``,
 ``min``, ``max``, ``clamp``, ``mix``, ``step``, ``smoothstep``,


### PR DESCRIPTION
### Description

When reading the docs, I noticed there was a stray tick mark showing itself on the website version.
I found it and removed it!

<img width="132" alt="Screenshot 2023-01-08 at 10 20 47 AM" src="https://user-images.githubusercontent.com/19540978/211207516-dcdb9fb5-b8e9-487b-8f8a-ff2463bf48fb.png">

### List of changes

- **removed** stray tick mark

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
