### PR TITLE
METH_NOARGS functions are not implemeted according to spec

### DIFF
--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -8303,7 +8303,7 @@ PyObject * MGLContext_clear_samplers(MGLContext * self, PyObject * args) {
     Py_RETURN_NONE;
 }
 
-PyObject * MGLContext_enter(MGLContext * self, PyObject *_null) {
+PyObject * MGLContext_enter(MGLContext * self, PyObject *args) {
     return PyObject_CallMethod(self->ctx, "__enter__", NULL);
 }
 
@@ -8311,7 +8311,7 @@ PyObject * MGLContext_exit(MGLContext * self, PyObject *args) {
     return PyObject_CallMethod(self->ctx, "__exit__", NULL);
 }
 
-PyObject * MGLContext_release(MGLContext * self, PyObject *_null) {
+PyObject * MGLContext_release(MGLContext * self, PyObject *args) {
     if (self->released) {
         Py_RETURN_NONE;
     }

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -8303,15 +8303,15 @@ PyObject * MGLContext_clear_samplers(MGLContext * self, PyObject * args) {
     Py_RETURN_NONE;
 }
 
-PyObject * MGLContext_enter(MGLContext * self) {
+PyObject * MGLContext_enter(MGLContext * self, PyObject *_null) {
     return PyObject_CallMethod(self->ctx, "__enter__", NULL);
 }
 
-PyObject * MGLContext_exit(MGLContext * self) {
+PyObject * MGLContext_exit(MGLContext * self, PyObject *args) {
     return PyObject_CallMethod(self->ctx, "__exit__", NULL);
 }
 
-PyObject * MGLContext_release(MGLContext * self) {
+PyObject * MGLContext_release(MGLContext * self, PyObject *_null) {
     if (self->released) {
         Py_RETURN_NONE;
     }


### PR DESCRIPTION
from
```
    {(char *)"__enter__", (PyCFunction)MGLContext_enter, METH_NOARGS},
    {(char *)"__exit__", (PyCFunction)MGLContext_exit, METH_VARARGS},
    {(char *)"release", (PyCFunction)MGLContext_release, METH_NOARGS},
```

nb there are other METH_NOARGS wrong signatures around, only fixing here what i'm hitting right now
