### PR TITLE
Fixed ComputeShader.run_indirect() and added missing method in cpp ob…

### DIFF
--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -250,7 +250,7 @@ class ComputeShader:
         return self.mglo.run(group_x, group_y, group_z)
 
     def run_indirect(self, buffer: 'Buffer', offset: int = 0) -> None:
-        return self.mglo.run(buffer, offset)
+        return self.mglo.run_indirect(buffer.mglo, offset)
 
     def get(self, key: str, default: Any) -> Union[Uniform, UniformBlock, Subroutine, Attribute, Varying]:
         return self._members.get(key, default)

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -9765,6 +9765,7 @@ PyMethodDef MGLBuffer_methods[] = {
 
 PyMethodDef MGLComputeShader_methods[] = {
     {(char *)"run", (PyCFunction)MGLComputeShader_run, METH_VARARGS},
+    {(char *)"run_indirect", (PyCFunction)MGLComputeShader_run_indirect, METH_VARARGS},
     {(char *)"release", (PyCFunction)MGLComputeShader_release, METH_VARARGS},
     {},
 };


### PR DESCRIPTION
### Description

Indirect dispatch in compute shader added in #563 curently does not work as it's invoking the `run` method, and the `run_indirect` method does not exist.

### List of changes

- Fixed `run_indirect()` method in `ComputeShader`.
- Added missing method in compute shader cpp implementation.

<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
