### PR TITLE
Fix names bug in _moderngl.py SPIR-V parser

### DIFF
--- a/_moderngl.py
+++ b/_moderngl.py
@@ -449,7 +449,7 @@ def parse_spv_inputs(program: int, spv: bytes) -> Dict[int, Attribute]:
         if opcode == 5:  # OpName
             # We can extract the name of some ids
             name_start, name_end = (idx + 2) * 4, (idx + args) * 4
-            extracted_names[token(idx + 1)] = spv[name_start:name_end].decode()
+            extracted_names[token(idx + 1)] = spv[name_start:name_end].decode().replace('\x00', '')
 
         if opcode == 59:  # OpVariable
             # We can extract if it is a vertex shader input or not


### PR DESCRIPTION
### Description

Past SPIR-V parser extracted_collected:
`dict_values([('main\x00\x00\x00\x00', -1, -1, -1), ('gl_PerVertex\x00\x00\x00\x00', -1, -1, 262215), ('\x00\x00\x00\x00', 3, -1, -1), ('in_vert\x00', 1, 35665, 0), ('o_color\x00', 3, 35666, 0), ('in_color\x00\x00\x00\x00', 1, 35666, 1), ('distance\x00\x00\x00\x00', 3, 5126, 1)])`

Future extracted_collected:
`dict_values([('main', -1, -1, -1), ('gl_PerVertex', -1, -1, 262215), ('', 3, -1, -1), ('in_vert', 1, 35665, 0), ('o_color', 3, 35666, 0), ('in_color', 1, 35666, 1), ('distance', 3, 5126, 1)])`

### List of changes

- **fixed** extracting names from SPIR-V binary