### PR TITLE
Fix ctx.depth_clamp_range documentation in __init__.pyi

### DIFF
--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -1472,9 +1472,9 @@ class Context:
         ctx.depth_func = '1'   # GL_ALWAYS
     '''
 
-    depth_clamp_range: Union[Tuple[int, int], None]
+    depth_clamp_range: Union[Tuple[float, float], None]
     '''
-    Setting up depth clamp range (write only, by default None).
+    Setting up depth clamp range (write only, by default ``None``).
 
     ``ctx.depth_clamp_range`` offers uniform use of GL_DEPTH_CLAMP and glDepthRange.
 
@@ -1482,13 +1482,16 @@ class Context:
     near limit of projection matrix.
     For example, this will allow you to draw between 0 and 1 in the Z (depth) coordinate,
     even if ``near`` is set to 0.5 in the projection matrix.
+
     .. Note:: All fragments outside the ``near`` of the projection matrix will have a depth of ``near``.
+
     See https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#Depth_clamping for more info.
 
     ``glDepthRange(nearVal, farVal)`` is needed to specify mapping of depth values from normalized device coordinates to window coordinates.
     See https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDepthRange.xhtml for more info.
 
     Example::
+
         ctx.depth_clamp_range = None  # It will glDisable(GL_DEPTH_CLAMP) and glDepthRange(0, 1)
         ctx.depth_clamp_range = (near, far)  # It will glEnable(GL_DEPTH_CLAMP) and glDepthRange(near, far)
     '''


### PR DESCRIPTION
### Description

I didn’t find the addition of `Context.depth_clamp_range` on the documentation site.
It looks like there are problems with readthedocs again, just in case I added some empty lines and at the same time changed the `int` type to `float`. It should work now.

### List of changes

- **fixed** ctx.depth_clamp_range documentation
- **changed** type `int` to type `float`