### PR TITLE
Fix the visiblity of ctx.depth_clamp_range description in the documentation

### DIFF
--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -1472,7 +1472,7 @@ class Context:
         ctx.depth_func = '1'   # GL_ALWAYS
     '''
 
-    depth_clamp_range: Union[Tuple[float, float], None]
+    depth_clamp_range: Tuple[float, float]
     '''
     Setting up depth clamp range (write only, by default ``None``).
 
@@ -1483,7 +1483,9 @@ class Context:
     For example, this will allow you to draw between 0 and 1 in the Z (depth) coordinate,
     even if ``near`` is set to 0.5 in the projection matrix.
 
-    .. Note:: All fragments outside the ``near`` of the projection matrix will have a depth of ``near``.
+    .. note::
+
+        All fragments outside the ``near`` of the projection matrix will have a depth of ``near``.
 
     See https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#Depth_clamping for more info.
 
@@ -1491,9 +1493,12 @@ class Context:
     See https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDepthRange.xhtml for more info.
 
     Example::
+        
+        # For glDisable(GL_DEPTH_CLAMP) and glDepthRange(0, 1)
+        ctx.depth_clamp_range = None
 
-        ctx.depth_clamp_range = None  # It will glDisable(GL_DEPTH_CLAMP) and glDepthRange(0, 1)
-        ctx.depth_clamp_range = (near, far)  # It will glEnable(GL_DEPTH_CLAMP) and glDepthRange(near, far)
+        # For glEnable(GL_DEPTH_CLAMP) and glDepthRange(near, far)
+        ctx.depth_clamp_range = (near, far)
     '''
 
     blend_func: Tuple[int, int]


### PR DESCRIPTION
### Description

Type `Union[Tuple[float, float], None]` python see as `typing.Optional[typing.Tuple[float, float]]`
Now, the type of `ctx.depth_clamp_range` in the docs is just `Tuple[float, float]`.
This is the last way to solve the problem.

### List of changes
- **fixed** visibility of `ctx.depth_clamp_range` in documentation