### PR TITLE
Fix the visiblity of ctx.depth_clamp_range description in the documentation [2]

### DIFF
--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -61,6 +61,7 @@ Attributes
 .. autoattribute:: Context.line_width
 .. autoattribute:: Context.point_size
 .. autoattribute:: Context.depth_func
+.. autoattribute:: Context.depth_clamp_range
 .. autoattribute:: Context.blend_func
 .. autoattribute:: Context.blend_equation
 .. autoattribute:: Context.viewport

--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -1472,7 +1472,7 @@ class Context:
         ctx.depth_func = '1'   # GL_ALWAYS
     '''
 
-    depth_clamp_range: Tuple[float, float]
+    depth_clamp_range: Union[Tuple[float, float], None]
     '''
     Setting up depth clamp range (write only, by default ``None``).
 


### PR DESCRIPTION
### Description

I forgot to add a line to `context.rst`, so `ctx.depth_clamp_range` was not listed in the documentation. :confused: 
This should definitely improve visibility.
I haven’t worked with sphinx yet, so I couldn’t test it myself, but I can confirm the successful compilation of `moderngl-stubs/__init__.pyi`.

Sorry for so many commits due to such a trivial mistake.

### List of changes

- **fixed** visibility of `ctx.depth_clamp_range` documentation
- **changed** restoring the previous  `ctx.depth_clamp_range` type to `Union[Tuple[float, float], None]` in the documentation