### PR TITLE
Update the documentation build description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ python3 setup.py install
 
 ```sh
 pip install -r docs/requirements.txt
-python setup.py build_sphinx
+python -m sphinx docs build/sphinx
 ```
 
 ### Running tests


### PR DESCRIPTION
### Description

Due to the deprecation of the previous method of assembling documentation, and its inoperability after updating `docs/requirements.txt`, I suggest updating this method in `README.md`

### List of changes

- **changed** old command `python setup.py build_sphinx` to new command `python -m sphinx docs build/sphinx` in `README.md`