### PR TITLE
Adding a test for ctx.depth_clamp_range

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -116,6 +116,12 @@ def test_enable_direct(ctx_new):
     ctx.disable_direct(GL_PROGRAM_POINT_SIZE)
     assert ctx.error == "GL_NO_ERROR"
 
+def test_depth_clamp_range(ctx):
+    ctx.depth_clamp_range = 0, 1
+    assert ctx.error == "GL_NO_ERROR"
+
+    ctx.depth_clamp_range = None
+    assert ctx.error == "GL_NO_ERROR"
 
 def test_info(ctx):
     assert isinstance(ctx.info, dict)


### PR DESCRIPTION
### Description

Hello! Recently, it seems that due to the release of a Mesa drivers update in Linux, the `glDepthRange()` function was temporarily broken, now it has been fixed, it works and `ctx.depth_clamp_range` along with it, but I think we need to add a test just in case.

<details>
<summary>I ran a new test myself, there were no errors, the PR is ready.</summary>

```
$ python3 -m pytest tests/
======================================= test session starts ========================================
platform linux -- Python 3.11.4, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/user/moderngl
collected 353 items                                                                                

tests/test_blend.py .......                                                                  [  1%]
tests/test_buffer.py ............                                                            [  5%]
tests/test_buffer_copy.py ..                                                                 [  5%]
tests/test_buffer_format.py .......                                                          [  7%]
tests/test_buffer_new.py ........                                                            [ 10%]
tests/test_buffer_read_errors.py ....                                                        [ 11%]
tests/test_buffer_read_into.py ...                                                           [ 12%]
tests/test_buffer_write_errors.py ....                                                       [ 13%]
tests/test_compute_shader.py ........                                                        [ 15%]
tests/test_compute_shader_uniform.py .                                                       [ 15%]
tests/test_context.py ...........                                                            [ 18%]
tests/test_cull_face.py .                                                                    [ 19%]
tests/test_depth_samplers.py ...                                                             [ 20%]
tests/test_framebuffer.py .....                                                              [ 21%]
tests/test_framebuffer_clear.py .                                                            [ 21%]
tests/test_framebuffer_half_float.py .                                                       [ 22%]
tests/test_framebuffer_masks.py ..                                                           [ 22%]
tests/test_framebuffer_read_channels.py .                                                    [ 22%]
tests/test_local.py .                                                                        [ 23%]
tests/test_padding.py ...                                                                    [ 24%]
tests/test_pbo.py .....                                                                      [ 25%]
tests/test_pbo_new.py .....                                                                  [ 26%]
tests/test_per_instance_attrib.py ......                                                     [ 28%]
tests/test_program.py ..                                                                     [ 29%]
tests/test_release.py ..........                                                             [ 32%]
tests/test_renderbuffer.py .....                                                             [ 33%]
tests/test_sampler.py ......                                                                 [ 35%]
tests/test_sampler_uniforms.py ..                                                            [ 35%]
tests/test_scissor.py ......                                                                 [ 37%]
tests/test_shader_includes.py .                                                              [ 37%]
tests/test_simple_buffer.py ........                                                         [ 39%]
tests/test_simple_compute_shader.py .                                                        [ 40%]
tests/test_simple_framebuffer.py ...................                                         [ 45%]
tests/test_simple_program.py .....                                                           [ 47%]
tests/test_simple_renderbuffer.py .....                                                      [ 48%]
tests/test_simple_texture.py ......................                                          [ 54%]
tests/test_simple_texture_3d.py .................                                            [ 59%]
tests/test_spirv_parsing.py .                                                                [ 59%]
tests/test_texture.py ..........                                                             [ 62%]
tests/test_texture_array.py ..                                                               [ 63%]
tests/test_texture_cube.py .....                                                             [ 64%]
tests/test_texture_external.py .                                                             [ 64%]
tests/test_texture_half_float.py .                                                           [ 65%]
tests/test_texture_new.py ....................                                               [ 70%]
tests/test_transform.py ........                                                             [ 73%]
tests/test_uniform.py .                                                                      [ 73%]
tests/test_uniform_block.py ..                                                               [ 73%]
tests/test_uniform_block_new.py .                                                            [ 74%]
tests/test_uniforms.py .........                                                             [ 76%]
tests/test_unnamed_01.py .                                                                   [ 77%]
tests/test_unnamed_02.py .                                                                   [ 77%]
tests/test_unnamed_03.py .                                                                   [ 77%]
tests/test_vao_attribs.py .                                                                  [ 77%]
tests/test_vertex_array.py .......                                                           [ 79%]
tests/test_vertex_array_index.py ..                                                          [ 80%]
tests/test_vertex_attribute_double_types.py ..........................                       [ 87%]
tests/test_vertex_attribute_types.py ..........................................              [ 99%]
tests/test_viewports.py .                                                                    [100%]

======================================= 353 passed in 1.49s ========================================
```

</details>

### List of changes

- **added** test for `ctx.depth_clamp_range`
