### PR TITLE
Improve consistency within PyOpenGL example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ With PyOpenGL, using the original OpenGL API, you have to write three lines to
 achieve a simple task like binding a VBO:
 
 ```py
-vbo1 = glGenBuffers(1)
-GL.glBindBuffer(GL_ARRAY_BUFFER, vbo1)
-GL.glBufferData(GL_ARRAY_BUFFER, b'Hello World!', GL_STATIC_DRAW)
+vbo1 = GL.glGenBuffers(1)
+GL.glBindBuffer(GL.GL_ARRAY_BUFFER, vbo1)
+GL.glBufferData(GL.GL_ARRAY_BUFFER, b'Hello World!', GL.GL_STATIC_DRAW)
 
-vbo2 = glGenBuffers(1)
-GL.glBindBuffer(GL_ARRAY_BUFFER, vbo2)
-GL.glBufferData(GL_ARRAY_BUFFER, b'\x00' * 1024, GL_DYNAMIC_DRAW)
+vbo2 = GL.glGenBuffers(1)
+GL.glBindBuffer(GL.GL_ARRAY_BUFFER, vbo2)
+GL.glBufferData(GL.GL_ARRAY_BUFFER, b'\x00' * 1024, GL.GL_DYNAMIC_DRAW)
 ```
 
 With ModernGL you need just one simple line per VBO to achieve the same


### PR DESCRIPTION
### Description

In the main README.md, there is a small example of PyOpenGL usage for comparison.  There was some inconsistency in how methods were called.  This is a trivial change to make the usage more consistent.