### PR TITLE
Replacing "video card" with "GPU" in rendering.rst guide

### DIFF
--- a/docs/the_guide/getting_started/rendering.rst
+++ b/docs/the_guide/getting_started/rendering.rst
@@ -5,7 +5,7 @@ Standalone rendering
 
 Standalone (offline) rendering allows you to render without using a window, and is included in ModernGL by default.
 
-To display the rendering result, we use the `Pillow (PIL)`_ library that comes with Python. Let's return the texture from the video card to RAM and call the ``PIL.Image.show()`` method to show it.
+To display the rendering result, we use the `Pillow (PIL)`_ library that comes with Python. Let's return the texture from the GPU memory to RAM and call the ``PIL.Image.show()`` method to show it.
 
 .. rubric:: Entire source
 


### PR DESCRIPTION
### Description

The term “video card” is not entirely correct, since ModernGL also works on integrated graphics. Therefore, I replace it with a "GPU".

### List of changes

- **changed** "video card" to "GPU"