### PR TITLE
Update "The Guide"

### DIFF
--- a/docs/reference/buffer.rst
+++ b/docs/reference/buffer.rst
@@ -50,21 +50,6 @@ Methods
     :param int offset: The offset.
     :param bytes chunk: The chunk to use repeatedly.
 
-.. py:method:: Buffer.orphan(size: int = -1) -> None:
-
-    Changing the buffer size.
-
-    This method expands or reduces the buffer. Its use is much more efficient and faster than creating a new buffer, since expanding a buffer in GPU memory is easier than creating a new one.
-
-    In OpenGL this is also called buffer re-specification.
-
-    :param int size: The new byte size of the buffer. If not supplied the buffer size will be unchanged.
-
-    Example::
-
-        buf = ctx.buffer(reserve=32)
-        buf.orphan(size=64)
-
 .. py:method:: Buffer.bind_to_uniform_block(binding: int = 0, *, offset: int = 0, size: int = -1) -> None:
 
     Bind the buffer to a uniform block.

--- a/docs/reference/buffer.rst
+++ b/docs/reference/buffer.rst
@@ -50,6 +50,21 @@ Methods
     :param int offset: The offset.
     :param bytes chunk: The chunk to use repeatedly.
 
+.. py:method:: Buffer.orphan(size: int = -1) -> None:
+
+    Changing the buffer size.
+
+    This method expands or reduces the buffer. Its use is much more efficient and faster than creating a new buffer, since expanding a buffer in GPU memory is easier than creating a new one.
+
+    In OpenGL this is also called buffer re-specification.
+
+    :param int size: The new byte size of the buffer. If not supplied the buffer size will be unchanged.
+
+    Example::
+
+        buf = ctx.buffer(reserve=32)
+        buf.orphan(size=64)
+
 .. py:method:: Buffer.bind_to_uniform_block(binding: int = 0, *, offset: int = 0, size: int = -1) -> None:
 
     Bind the buffer to a uniform block.

--- a/docs/the_guide/getting_started/vertex_array.rst
+++ b/docs/the_guide/getting_started/vertex_array.rst
@@ -5,7 +5,7 @@ Vertex Array
 
 :py:class:`VertexArray` is something like a pipeline, where as arguments it takes a :py:class:`Program`, a :py:class:`Buffer` with input data, and the names of input variables for this program.
 
-Vertex Array in ModernGL can be initialized in two ways: one buffer for all input variables or one buffer for each input variable.
+:py:class:`VertexArray` in ModernGL can be initialized in two ways: one buffer for all input variables or one buffer for each input variable.
 
 One input buffer for all input variables (simple :py:class:`VertexArray` version)::
     

--- a/docs/the_guide/getting_started/vertex_array.rst
+++ b/docs/the_guide/getting_started/vertex_array.rst
@@ -3,25 +3,26 @@
 Vertex Array
 ============
 
-:py:class:`VertexArray` is something like a pipeline, where as arguments it takes a :py:class:`Program`, a :py:class:`Buffer` with input data, and the names of input variables for this program.
+:py:class:`VertexArray` is something like a pipeline, where as arguments :py:meth:`Context.vertex_array` takes a :py:class:`Program`, a :py:class:`Buffer` with input data, and the names of input variables for this program.
 
-:py:class:`VertexArray` in ModernGL can be initialized in two ways: one buffer for all input variables or one buffer for each input variable.
+:py:class:`VertexArray` in ModernGL can be initialized in two ways: one buffer for all input variables or multiple buffers for all input variables.
 
 One input buffer for all input variables (simple :py:class:`VertexArray` version)::
     
     vao = ctx.vertex_array(program, buffer, 'input_var1', 'input_var2')
 
-One buffer for each input variable::
+Multiple input buffers for all input variables::
     
     vao = ctx.vertex_array(
         program,
         [
-            (buffer1, '3f', 'input_var1'),
-            (buffer2, '2f', 'input_var2')
+            (buffer1, '3f 2f', 'input_var1', 'input_var2'),
+            (buffer2, '4f', 'input_var3')
         ]
     )
     
-You can understand ``'3f'`` and ``'2f'`` as the type of the input variable, that is, 3 floats, which form ``vec3`` and 2 floats, which form ``vec2``.
+You can understand ``'3f 2f'`` and ``'4f'`` as the type of the input variable (or variables), that is, 3 floats and 2 floats, which form, for example, ``vec3 + vec2`` and 4 floats, which form ``vec4``.
+
 
 In our example we use a simple implementation of this method.
 


### PR DESCRIPTION
### Description

Adding methods `Buffer.read()` and `Buffer.write()` to the `buffer.rst` guide and one internal link to the `vertex_array.rst` guide. Returning `Buffer.orphan()` to the documentation with some changes.

@szabolcsdombi the date in the documentation is outdated, it will soon be 2024. :thinking: 
![image](https://github.com/moderngl/moderngl/assets/68602173/35824355-5fc6-4922-b94e-368060c2a57d)
I'm not changing it because, as I said in this PR #633, I see it as your signature. Would you mind if I update it?

### List of changes

- **added** `Buffer.orphan()` method description, one internal link to the `vertex_array.rst` guide
- **changed** `buffer.rst` guide, possibilities when creating VertexArray in `vertex_array.rst` guide