### PR TITLE
Adding direct begin()/end() Query methods

### DIFF
--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -117,6 +117,12 @@ class Query:
     def __exit__(self, *args):
         self.mglo.end()
 
+    def begin(self):
+        self.mglo.begin()
+
+    def end(self):
+        self.mglo.end()
+
     @property
     def samples(self):
         return self.mglo.samples


### PR DESCRIPTION
### Description

Using the "with" construct to enclose part of the code is inappropriate in some situations. Sometimes you just need to measure the number of rendered samples and because of this, shifting the entire code by 4 spaces can be inconvenient.

Therefore, I suggest adding the following methods. I'll add an example in the documentation later.

How adding will fix this situation:
```py
# Old
while 1:
    with query:
        # ... large rendering code ...
        # because of the "with" you will have to indent

    print("result:", query.samples)
```
```py
# New
while 1:
    query.begin()
    # ... large rendering code ...
    query.end()

    print("result:", query.samples)
```

### List of changes

- **added** direct begin()/end() Query methods