### PR TITLE
Adding an empty .release() method to DefaultLoader

### DIFF
--- a/_moderngl.py
+++ b/_moderngl.py
@@ -253,6 +253,9 @@ class DefaultLoader:
 
     def __exit__(self, *args):
         pass
+    
+    def release(self):
+        pass
 
 
 class Error(Exception):


### PR DESCRIPTION
The `.release()` method is [required](https://github.com/moderngl/moderngl/blob/5f5beb4bd92915a88e90955450965ba9ed7889c0/src/moderngl.cpp#L7627C1-L7649C2) for every loader, just like the `.__enter__()` and `.__exit__()` methods.

- **added** empty method `DefaultLoader.release()`