### PR TITLE
Fix variable type "*attribute" in ctx.simple_vertex_array() in __init__.pyi

### DIFF
--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -1974,7 +1974,7 @@ class Context:
         self,
         program: Program,
         buffer: Buffer,
-        *attributes: Union[List[str], Tuple[str, ...]],
+        *attributes: str,
         index_buffer: Optional[Buffer] = None,
         index_element_size: int = 4,
         mode: Optional[int] = None,


### PR DESCRIPTION
Fixes #677

- **changed** `*attirbutes` variable type from `Union[List[str], Tuple[str, ...]]` to `str`