### PR TITLE
Add a pyinstaller hook for easier distribution

### DIFF
--- a/moderngl/__pyinstaller/__init__.py
+++ b/moderngl/__pyinstaller/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]

--- a/moderngl/__pyinstaller/hook-moderngl.py
+++ b/moderngl/__pyinstaller/hook-moderngl.py
@@ -1,0 +1,1 @@
+hiddenimports = ["glcontext"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[options.entry_points]
+pyinstaller40 =
+	hook-dirs = moderngl.__pyinstaller:get_hook_dirs

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     keywords=keywords,
     include_package_data=True,
     package_data={"moderngl-stubs": ["__init__.pyi"]},
-    packages=["moderngl", "moderngl-stubs"],
+    packages=["moderngl", "moderngl-stubs", "moderngl.__pyinstaller"],
     py_modules=["_moderngl"],
     ext_modules=[mgl],
     platforms=["any"],


### PR DESCRIPTION
When moderngl is built into a pyinstaller executable with default settings, it fails at runtime with this error `ModuleNotFoundError: No module named 'glcontext'`

This is because Pyinstaller can only follow imports in Python, and glcontext is imported in C++ code.

To get around this, this commit adds a pyinstaller hook that adds glcontext as a hidden import, tipping pyinstaller off to add that to the build.

Users can achieve this same outcome with Pyinstaller's `--hidden-import` flag, but this will do it automatically so users don't need to worry about it.

Documentation: https://pyinstaller.org/en/stable/hooks.html
We do the same thing in pygame-ce. https://github.com/pygame-community/pygame-ce/tree/main/src_py/__pyinstaller

User reports of this problem:
https://stackoverflow.com/questions/72822188/freezing-python-moderngl-application-with-pyinstaller
https://discord.com/channels/772505616680878080/1220826955688054844