### PR TITLE
Add hidden imports to init.py

### DIFF
--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -12,6 +12,12 @@ except ImportError:
 __version__ = "6.0.0"
 
 
+def packager_imports():
+    """some additional imports that code freezers (Pyinstaller,etc) should see."""
+
+    import glcontext
+
+
 class _store:
     default_context = None
 

--- a/moderngl/__pyinstaller/__init__.py
+++ b/moderngl/__pyinstaller/__init__.py
@@ -1,5 +1,0 @@
-import os
-
-
-def get_hook_dirs():
-    return [os.path.dirname(__file__)]

--- a/moderngl/__pyinstaller/hook-moderngl.py
+++ b/moderngl/__pyinstaller/hook-moderngl.py
@@ -1,1 +1,0 @@
-hiddenimports = ["glcontext"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[options.entry_points]
-pyinstaller40 =
-	hook-dirs = moderngl.__pyinstaller:get_hook_dirs

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     keywords=keywords,
     include_package_data=True,
     package_data={"moderngl-stubs": ["__init__.pyi"]},
-    packages=["moderngl", "moderngl-stubs", "moderngl.__pyinstaller"],
+    packages=["moderngl", "moderngl-stubs"],
     py_modules=["_moderngl"],
     ext_modules=[mgl],
     platforms=["any"],


### PR DESCRIPTION
Alternate solution for #680, reverts the changes of #680.

Makes sure glcontext can be picked up as a dependency by code-freezing tools, so that programs can be easily packaged into executables without any special actions by users.

Reviewers: if there's anything you'd like to change with this, feel free to push to my branch.