### PR TITLE
Add support for Per-Fragment Logical Operations (COLOR_LOGIC_OP) (Section 17.3.9 in 4.6 core)

### DIFF
--- a/examples/color_logic_ops.py
+++ b/examples/color_logic_ops.py
@@ -1,0 +1,96 @@
+'''
+Demonstrates Per-Fragment Blending operation called Logical Operation.
+Instead of blending fragment color based on linear combinations with alpha
+channel, uses bitwise logical operations.
+
+Defined in Section 17.3.9 of
+https://registry.khronos.org/OpenGL/specs/gl/glspec46.core.pdf
+
+Renders four overlapping squares.
+Square i [0, 4) is assigned a red channel with value (1<<i).
+
+'''
+import numpy as np
+import moderngl as gl
+from _example import Example
+
+class LogicalOp(Example):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # Blending will take bitwise OR between fragment color and
+        # destination framebuffer color
+        self.ctx.enable(gl.COLOR_LOGIC_OP)
+
+        # ctx.logic_op can be one of 
+        # gl.{AND,AND_REVERSE,COPY,AND_INVERTED,NOOP,XOR,OR,NOR,EQUIV,
+        #     INVERT,OR_REVERSE,COPY_INVERTED,OR_INVERTED,NAND,SET}
+        # See Table 17.3 of https://registry.khronos.org/OpenGL/specs/gl/glspec46.core.pdf
+        self.ctx.logic_op = gl.OR
+
+        self.prog = self.ctx.program(
+            vertex_shader='''
+                #version 330
+                in vec2 point;
+                in uint label;
+                flat out uint out_value;
+
+                void main() {
+                  gl_Position = vec4(point * 2 - 1, 0.0, 1.0);
+                  out_value = label; 
+                }
+            ''',
+            fragment_shader='''
+                #version 330
+                flat in uint out_value;
+                out vec4 out_color;
+
+                void main() {
+                  float scaled = float(out_value) / 16;
+                  out_color = vec4(scaled, 0.0, scaled, 1.0);
+                }
+            ''')
+
+        def make_quad(origin, size):
+            quad = np.array([
+                0, 0, 1, 0, 1, 1,
+                0, 0, 1, 1, 0, 1,
+                ]).astype('f4').reshape(-1, 2)
+            quad *= size
+            quad += origin 
+            return quad
+
+        # Four overlapping squares
+        vertices = np.stack([
+            make_quad((1.0, 1.0), (2, 2)),
+            make_quad((2.6, 1.0), (2, 2)),
+            make_quad((1.0, 2.6), (2, 2)),
+            make_quad((2.6, 2.6), (2, 2))
+            ]).flatten().astype('f4')
+        vertices /= (vertices.max() + 1)
+
+        print('vertices:\n', vertices.reshape(-1,2))
+        self.vbo = self.ctx.buffer(vertices)
+
+        # the labels associated with each square
+        labels = np.concatenate([np.full(6, 1<<i) for i in range(4)]).astype('u4')
+        self.labels_buf = self.ctx.buffer(labels)
+        print(f'{vertices.shape=} {labels.shape=}')
+        print(f'{self.prog._members.keys()=}')
+
+        content = ((self.vbo, '2f4', 'point'), 
+                   (self.labels_buf, '1u4', 'label'))
+        self.vao = self.ctx.vertex_array(self.prog, content, mode=gl.TRIANGLES)
+
+    def render(self, time, frame_time):
+        # self.vbo.use()
+        self.vao.render()
+        
+
+if __name__ == '__main__':
+    LogicalOp.run()
+
+
+
+

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -1202,6 +1202,7 @@ class Context:
     CULL_FACE = 4
     RASTERIZER_DISCARD = 8
     PROGRAM_POINT_SIZE = 16
+    COLOR_LOGIC_OP = 32
 
     # Primitive modes
 
@@ -1251,6 +1252,25 @@ class Context:
     FUNC_REVERSE_SUBTRACT = 0x800B
     MIN = 0x8007
     MAX = 0x8008
+
+    # Logic Ops
+
+    CLEAR = 0x1500
+    AND = 0x1501
+    AND_REVERSE = 0x1502
+    COPY = 0x1503
+    AND_INVERTED = 0x1504
+    NOOP = 0x1505
+    XOR = 0x1506
+    OR = 0x1507
+    NOR = 0x1508
+    EQUIV = 0x1509
+    INVERT = 0x150A
+    OR_REVERSE = 0x150B
+    COPY_INVERTED = 0x150C
+    OR_INVERTED = 0x150D
+    NAND = 0x150E
+    SET = 0x150F
 
     # Provoking vertex
 
@@ -1359,6 +1379,14 @@ class Context:
             self.mglo.blend_equation = tuple([value])
         else:
             self.mglo.blend_equation = tuple(value)
+
+    @property
+    def logic_op(self):
+        raise NotImplementedError()
+
+    @logic_op.setter
+    def logic_op(self, value):
+        self.mglo.logic_op = tuple([value])
 
     @property
     def depth_clamp_range(self):
@@ -2035,6 +2063,7 @@ def _resolve_module_constants(scope):
         "CULL_FACE",
         "RASTERIZER_DISCARD",
         "PROGRAM_POINT_SIZE",
+        "COLOR_LOGIC_OP",
         "POINTS",
         "LINES",
         "LINE_LOOP",
@@ -2071,6 +2100,25 @@ def _resolve_module_constants(scope):
         "FUNC_REVERSE_SUBTRACT",
         "MIN",
         "MAX",
+        # Table 17.3 from https://registry.khronos.org/OpenGL/specs/gl/glspec46.core.pdf 
+        # LogicOp 
+        "CLEAR",
+        "AND",
+        "AND_REVERSE",
+        "COPY",
+        "AND_INVERTED",
+        "NOOP",
+        "XOR",
+        "OR",
+        "NOR",
+        "EQUIV",
+        "INVERT",
+        "OR_REVERSE",
+        "COPY_INVERTED",
+        "OR_INVERTED",
+        "NAND",
+        "SET",
+        # end of table 17.3
         "FIRST_VERTEX_CONVENTION",
         "LAST_VERTEX_CONVENTION",
         "VERTEX_ATTRIB_ARRAY_BARRIER_BIT",

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -30,6 +30,7 @@ enum MGLEnableFlag {
     MGL_CULL_FACE = 4,
     MGL_RASTERIZER_DISCARD = 8,
     MGL_PROGRAM_POINT_SIZE = 16,
+    MGL_COLOR_LOGIC_OP = 32,
     MGL_INVALID = 0x40000000,
 };
 
@@ -98,6 +99,7 @@ struct MGLContext {
     int enable_flags;
     int front_face;
     int cull_face;
+    int logic_op;
     int depth_func;
     bool depth_clamp;
     double depth_range[2];
@@ -3458,6 +3460,12 @@ static PyObject * MGLScope_begin(MGLScope * self, PyObject * args) {
         gl.Enable(GL_PROGRAM_POINT_SIZE);
     } else {
         gl.Disable(GL_PROGRAM_POINT_SIZE);
+    }
+
+    if (flags & MGL_COLOR_LOGIC_OP) {
+        gl.Enable(GL_COLOR_LOGIC_OP);
+    } else {
+        gl.Disable(GL_COLOR_LOGIC_OP);
     }
 
     Py_RETURN_NONE;
@@ -7245,6 +7253,10 @@ static PyObject * MGLContext_enable(MGLContext * self, PyObject * args) {
         self->gl.Enable(GL_PROGRAM_POINT_SIZE);
     }
 
+    if (flags & MGL_COLOR_LOGIC_OP) {
+        self->gl.Enable(GL_COLOR_LOGIC_OP);
+    }
+
     Py_RETURN_NONE;
 }
 
@@ -7281,6 +7293,10 @@ static PyObject * MGLContext_disable(MGLContext * self, PyObject * args) {
 
     if (flags & MGL_PROGRAM_POINT_SIZE) {
         self->gl.Disable(GL_PROGRAM_POINT_SIZE);
+    }
+
+    if (flags & MGL_COLOR_LOGIC_OP) {
+        self->gl.Disable(GL_COLOR_LOGIC_OP);
     }
 
     Py_RETURN_NONE;
@@ -8022,6 +8038,29 @@ static int MGLContext_set_blend_equation(MGLContext * self, PyObject * value, vo
     }
 
     self->gl.BlendEquationSeparate(equation[0], equation[1]);
+    return 0;
+}
+
+static PyObject * MGLContext_get_logic_op(MGLContext * self, void * closure) {
+    int logic_op = self->logic_op;
+    return PyLong_FromLong(logic_op);
+}
+
+static int MGLContext_set_logic_op(MGLContext * self, PyObject * value, void * closure) {
+    int op;
+
+    int args_ok = PyArg_ParseTuple(
+        value,
+        "i",
+        &op
+    );
+
+    if (!args_ok) {
+        return 0;
+    }
+
+    self->logic_op = op;
+    self->gl.LogicOp(self->logic_op);
     return 0;
 }
 
@@ -8857,6 +8896,7 @@ static PyGetSetDef MGLContext_getset[] = {
     {(char *)"depth_clamp_range", (getter)MGLContext_get_depth_clamp_range, (setter)MGLContext_set_depth_clamp_range},
     {(char *)"blend_func", (getter)MGLContext_get_blend_func, (setter)MGLContext_set_blend_func},
     {(char *)"blend_equation", (getter)MGLContext_get_blend_equation, (setter)MGLContext_set_blend_equation},
+    {(char *)"logic_op", (getter)MGLContext_get_logic_op, (setter)MGLContext_set_logic_op},
     {(char *)"multisample", (getter)MGLContext_get_multisample, (setter)MGLContext_set_multisample},
 
     {(char *)"provoking_vertex", (getter)MGLContext_get_provoking_vertex, (setter)MGLContext_set_provoking_vertex},


### PR DESCRIPTION
Hi,

I wondered if you might consider this, it is added support for OpenGL's target `COLOR_LOGIC_OP` for `gl.Enable`, which allows 'blending' using bitwise logical ops.

I basically just followed the style and conventions in `moderngl/__init__.py` and `src/moderngl.cpp`.

Also added a test script in examples/color_logic_ops.py

Synopsis:

```python
import moderngl as gl
ctx.enable(gl.COLOR_LOGIC_OP)
ctx.logic_op = gl.OR 
# logic_op can be any bitwise op as listed in Table 17.3
# CLEAR, AND, AND_REVERSE, COPY, AND_INVERTED, NOOP, XOR
# OR, NOR, EQUIV, INVERT, OR_REVERSE, COPY_INVERTED, OR_INVERTED
# NAND, SET
...
```

See [4.6 Core Specification](https://registry.khronos.org/OpenGL/specs/gl/glspec46.core.pdf)
![image](https://github.com/moderngl/moderngl/assets/5355286/d41fe150-edbf-4be7-88b0-916c7ce80097)
