### PR TITLE
Adding automatic compilation of GLSL code to SPIR-V

### DIFF
--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -247,7 +247,7 @@ Objects
     :param bool time: Query ``GL_TIME_ELAPSED`` or not.
     :param bool primitives: Query ``GL_PRIMITIVES_GENERATED`` or not.
 
-.. py:method:: Context.compute_shader(source: str, to_spirv: bool = False)
+.. py:method:: Context.compute_shader(source: str, to_spirv: bool = False) -> ComputeShader
 
     A :py:class:`ComputeShader` is a Shader Stage that is used entirely \
     for computing arbitrary information. While it can do rendering, it \

--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -30,7 +30,7 @@ Objects
     :param str tess_evaluation_shader: The tessellation evaluation shader source.
     :param list varyings: A list of varyings.
     :param dict fragment_outputs: A dictionary of fragment outputs.
-    :param bool to_spirv: Compile shaders to SPIR-V using ``glslangValidator`` (to use this parameter, install ``glslang-tools`` on Linux or Vulkan SDK on Windows/macOS and configure PATH).
+    :param bool to_spirv: Compile the shaders to SPIRV using ``glslangValidator`` or ``glslc``. To use ``glslangValidator``, install ``glslang-tools`` on Linux or **Vulkan SDK** on Windows/macOS and configure the ``PATH``. For ``glslc``, make sure that you have the **Vulkan SDK** installed and configured correctly.
 
 .. py:method:: Context.buffer(data = None, reserve: int = 0, dynamic: bool = False) -> Buffer
 
@@ -254,7 +254,7 @@ Objects
     is generally used for tasks not directly related to drawing.
 
     :param str source: The source of the compute shader.
-    :param bool to_spirv: Compile shader to SPIR-V using ``glslangValidator`` (to use this parameter, install ``glslang-tools`` on Linux or Vulkan SDK on Windows/macOS and configure PATH).
+    :param bool to_spirv: Compile the shader to SPIRV using ``glslangValidator`` or ``glslc``. To use ``glslangValidator``, install ``glslang-tools`` on Linux or **Vulkan SDK** on Windows/macOS and configure the ``PATH``. For ``glslc``, make sure that you have the **Vulkan SDK** installed and configured correctly.
 
 External Objects
 ----------------

--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -12,7 +12,7 @@ Context
 Objects
 -------
 
-.. py:method:: Context.program(vertex_shader: str, fragment_shader: str, geometry_shader: str, tess_control_shader: str, tess_evaluation_shader: str, varyings: Tuple[str, ...], fragment_outputs: Dict[str, int], varyings_capture_mode: str = 'interleaved') -> Program
+.. py:method:: Context.program(vertex_shader: str, fragment_shader: str, geometry_shader: str, tess_control_shader: str, tess_evaluation_shader: str, varyings: Tuple[str, ...], fragment_outputs: Dict[str, int], varyings_capture_mode: str = 'interleaved', to_spirv: bool = False) -> Program
 
     Create a :py:class:`Program` object.
 
@@ -30,6 +30,7 @@ Objects
     :param str tess_evaluation_shader: The tessellation evaluation shader source.
     :param list varyings: A list of varyings.
     :param dict fragment_outputs: A dictionary of fragment outputs.
+    :param bool to_spirv: Compile shaders to SPIR-V using ``glslangValidator`` (to use this parameter, install ``glslang-tools`` on Linux or Vulkan SDK on Windows/macOS and configure PATH).
 
 .. py:method:: Context.buffer(data = None, reserve: int = 0, dynamic: bool = False) -> Buffer
 
@@ -246,13 +247,14 @@ Objects
     :param bool time: Query ``GL_TIME_ELAPSED`` or not.
     :param bool primitives: Query ``GL_PRIMITIVES_GENERATED`` or not.
 
-.. py:method:: Context.compute_shader(...)
+.. py:method:: Context.compute_shader(source: str, to_spirv: bool = False)
 
     A :py:class:`ComputeShader` is a Shader Stage that is used entirely \
     for computing arbitrary information. While it can do rendering, it \
     is generally used for tasks not directly related to drawing.
 
     :param str source: The source of the compute shader.
+    :param bool to_spirv: Compile shader to SPIR-V using ``glslangValidator`` (to use this parameter, install ``glslang-tools`` on Linux or Vulkan SDK on Windows/macOS and configure PATH).
 
 External Objects
 ----------------

--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -2035,7 +2035,7 @@ class Context:
             fragment_outputs (dict): A dictionary of fragment outputs.
 
         Keyword Args:
-            to_spirv (bool): Compile shaders to SPIR-V using glslangValidator.
+            to_spirv (bool): Compile shaders to SPIR-V using ``glslangValidator`` or ``glslc``.
 
         Returns:
             :py:class:`Program` object
@@ -2175,7 +2175,7 @@ class Context:
             source (str): The source of the compute shader.
 
         Keyword Args:
-            to_spirv (bool): Compile shader to SPIR-V using glslangValidator.
+            to_spirv (bool): Compile shader to SPIR-V using ``glslangValidator`` or ``glslc``.
 
         Returns:
             :py:class:`ComputeShader` object

--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -1119,7 +1119,7 @@ class Context:
     See https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDepthRange.xhtml for more info.
 
     Example::
-        
+
         # For glDisable(GL_DEPTH_CLAMP) and glDepthRange(0, 1)
         ctx.depth_clamp_range = None
 
@@ -2013,6 +2013,7 @@ class Context:
         varyings: Tuple[str, ...] = (),
         fragment_outputs: Optional[Dict[str, int]] = None,
         varyings_capture_mode: str = "interleaved",
+        to_spirv: bool = False
     ) -> Program:
         """
         Create a :py:class:`Program` object.
@@ -2032,6 +2033,10 @@ class Context:
             tess_evaluation_shader (str): The tessellation evaluation shader source.
             varyings (list): A list of varyings.
             fragment_outputs (dict): A dictionary of fragment outputs.
+
+        Keyword Args:
+            to_spirv (bool): Compile shaders to SPIR-V using glslangValidator.
+
         Returns:
             :py:class:`Program` object
         """
@@ -2160,7 +2165,7 @@ class Context:
         Returns:
             :py:class:`Renderbuffer` object
         """
-    def compute_shader(self, source: str | bytes | ConvertibleToShaderSource) -> "ComputeShader":
+    def compute_shader(self, source: str | bytes | ConvertibleToShaderSource, to_spirv: bool = False) -> "ComputeShader":
         """
         A :py:class:`ComputeShader` is a Shader Stage that is used entirely \
         for computing arbitrary information. While it can do rendering, it \
@@ -2168,6 +2173,9 @@ class Context:
 
         Args:
             source (str): The source of the compute shader.
+
+        Keyword Args:
+            to_spirv (bool): Compile shader to SPIR-V using glslangValidator.
 
         Returns:
             :py:class:`ComputeShader` object

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -3,6 +3,7 @@ from collections import deque
 
 from _moderngl import Attribute, Error, InvalidObject, StorageBlock, Subroutine, Uniform, UniformBlock, Varying
 from _moderngl import parse_spv_inputs as _parse_spv
+from _moderngl import convert_glsl_to_spirv as _to_spv
 
 try:
     from moderngl import mgl
@@ -1705,7 +1706,20 @@ class Context:
         fragment_outputs=None,
         attributes=None,
         varyings_capture_mode="interleaved",
+        to_spirv=False,
     ):
+        if to_spirv:
+            if vertex_shader is not None:
+                vertex_shader = _to_spv(vertex_shader, 'vert')
+            if fragment_shader is not None:
+                fragment_shader = _to_spv(fragment_shader, 'frag')
+            if geometry_shader is not None:
+                geometry_shader = _to_spv(geometry_shader, 'geom')
+            if tess_control_shader is not None:
+                tess_control_shader = _to_spv(tess_control_shader, 'tesc')
+            if tess_evaluation_shader is not None:
+                tess_evaluation_shader = _to_spv(tess_evaluation_shader, 'tese')
+
         if varyings_capture_mode not in ("interleaved", "separate"):
             raise ValueError("varyings_capture_mode must be interleaved or separate")
 
@@ -1861,7 +1875,10 @@ class Context:
         res.extra = None
         return res
 
-    def compute_shader(self, source):
+    def compute_shader(self, source, to_spirv=False):
+        if to_spirv:
+            source = _to_spv(source, 'comp')
+
         res = ComputeShader.__new__(ComputeShader)
         res.mglo, _members, _, _, res._glo = self.mglo.program(
             None,


### PR DESCRIPTION
Hello, I propose adding automatic compilation of GLSL shader code to SPIR-V. The new method uses `glslangValidator` call via `subprocess` and thus precompiles the code in SPIR-V, and also writes more detailed errors (in most cases). The method is built into `Context.program()` and `Contex.compute_shader()`, its call is provided by enabling the `to_spirv` flag, which is disabled by default.

At the moment, only `mgl.ComputeShader` work well. There is a bug in `mgl.Program` related to a problem extracting `varyings` from a shader and I need help figuring it out.

<br>
<details>

<summary>Example of use (ComputeShader)</summary>

```py
import moderngl as mgl
import numpy as np


ctx = mgl.create_context(standalone=True)

comp = ctx.compute_shader("""
#version 430

layout(local_size_x = 1024, local_size_y = 1, local_size_z = 1) in;

layout(std430, binding = 0) buffer InputA {
    float valuesA[];
};

layout(std430, binding = 1) buffer InputB {
    float valuesB[];
};

layout(std430, binding = 2) buffer Results {
    float results[];
};

layout(std140, binding = 3) uniform Result_size {
    uint results_size;
};

void main() {
    uint idx = gl_GlobalInvocationID.x;
    if (idx < results_size) {
        results[idx] = valuesA[idx] * valuesB[idx];
    }
}
""", to_spirv=True)

valuesA = np.array([2, 4, 6], dtype=np.float32)
valuesB = np.array([3, 5, 7], dtype=np.float32)

bufferA = ctx.buffer(valuesA)
bufferB = ctx.buffer(valuesB)
result_buffer = ctx.buffer(reserve=bufferA.size)

res_size_data = np.array([len(valuesA)], dtype=np.uint32)
res_size_buffer = ctx.buffer(res_size_data)

bufferA.bind_to_storage_buffer(0)
bufferB.bind_to_storage_buffer(1)
result_buffer.bind_to_storage_buffer(2)
res_size_buffer.bind_to_uniform_block(3)

comp.run(valuesA.shape[0] // 1024 + int(valuesA.shape[0] % 1024 > 0))

result_data = np.frombuffer(result_buffer.read(), dtype=np.float32)
print(result_data)
```
```sh
$ python3 t3.py 
[ 6. 20. 42.]
```
</details>

<details>

<summary>Example of use (Program (transforms)  (not works for now))</summary>

```py
import moderngl as mgl
import numpy as np


ctx = mgl.create_context(standalone=True)

prog = ctx.program(vertex_shader="""
#version 430

layout(location = 0) in float var1;
layout(location = 1) in float var2;

layout(location = 0) out float var3;

void main() {
    var3 = var1 * var2;
}
""", varyings=('var3',), to_spirv=True)

values = np.array([
    2, 3,
    4, 5,
    6, 7
], dtype=np.float32)

vbo = ctx.buffer(values.tobytes())
vao = ctx.vertex_array(prog, [
    (vbo, 'f f', 'var1', 'var2')
])

num_vertices = len(values) // 2

result_buffer = ctx.buffer(reserve=num_vertices * 4)

ctx.enable(ctx.RASTERIZER_DISCARD)
vao.transform(result_buffer, vertices=num_vertices)
ctx.disable(ctx.RASTERIZER_DISCARD)
ctx.finish()

result_data = np.frombuffer(result_buffer.read(), dtype=np.float32)
print(result_data)
```
```sh
$ python3 t3.py 
Traceback (most recent call last):
  File "/home/user/t3.py", line 36, in <module>
    vao.transform(result_buffer, vertices=num_vertices)
  File "/home/user/Github/ModernGL/moderngl/moderngl/__init__.py", line 1181, in transform
    self.mglo.transform(outputs, mode, vertices, first, instances, buffer_offset)
_moderngl.Error: the program has no varyings
```
</details>