### PR TITLE
Add a method to clear outstanding OpenGL errors

### DIFF
--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -2268,6 +2268,46 @@ class Context:
         Standalone contexts can normally be released.
         """
 
+    def clear_errors(self) -> None:
+        """
+        Clears all outstanding OpenGL errors,
+        such that calling :py:meth:`Context.error` immediately afterward
+        will return ``"GL_NO_ERROR"``.
+
+        This method is intended for applications
+        that use additional OpenGL libraries to access this context.
+        It should be used immediately before calling any such libraries,
+        so as not to impact their own error-reporting.
+
+        Because the same error flag is shared by all OpenGL functions,
+        an error originating in ``moderngl``
+        may inadvertently be reported by another library when it calls ``glGetError``.
+        This complicates debugging.
+
+        .. code-block:: python
+
+            from OpenGL import GL
+
+            ctx = moderngl.create_context()
+
+            # 1 is not a valid value for glEnable, so this will set GL_INVALID_ENUM.
+            ctx.enable_direct(1)
+
+            # But if not for this method...
+            ctx.clear_errors()
+
+            # ...then this unrelated PyOpenGL call will raise an exception
+            # for the error that was actually set by moderngl.
+            # It will look like this method caused the error, despite being used correctly!
+            GL.glHint(GL.GL_LINE_SMOOTH_HINT, GL.GL_NICEST)
+
+        :: tip ..
+
+            If your application only uses OpenGL through moderngl,
+            then you most likely won't need this method.
+        """
+
+
 def create_context(
     require: Optional[int] = None,
     standalone: bool = False,

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -1943,6 +1943,10 @@ class Context:
             self.mglo.release()
             self.mglo = InvalidObject()
 
+    def clear_errors(self):
+        if not isinstance(self.mglo, InvalidObject):
+            self.mglo.clear_errors()
+
 
 def create_context(require=None, standalone=False, share=False, **settings):
     if require is None:

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -7673,6 +7673,19 @@ static PyObject * MGLContext_release(MGLContext * self, PyObject * args) {
     Py_RETURN_NONE;
 }
 
+static PyObject * MGLContext_clear_errors(MGLContext * self, PyObject * args) {
+    // According to the OpenGL wiki, OpenGL can hold multiple error flags.
+    // (Contrast with something like the C stdlib's errno, which is a single global variable.)
+    // Calling glGetError returns one of these error codes and clears it,
+    // but there may still be others.
+    // Therefore, they recommend calling glGetError in a loop until it returns GL_NO_ERROR.
+    // See https://www.khronos.org/opengl/wiki/OpenGL_Error#Catching_errors_(the_hard_way)
+    // See the Python API docs for this method for info about its use case.
+    while (self->gl.GetError() != GL_NO_ERROR);
+
+    Py_RETURN_NONE;
+}
+
 static PyObject * MGLContext_get_ubo_binding(MGLContext * self, PyObject * args) {
     int program_obj;
     int index;
@@ -8866,6 +8879,7 @@ static PyMethodDef MGLContext_methods[] = {
     {(char *)"__enter__", (PyCFunction)MGLContext_enter, METH_NOARGS},
     {(char *)"__exit__", (PyCFunction)MGLContext_exit, METH_VARARGS},
     {(char *)"release", (PyCFunction)MGLContext_release, METH_NOARGS},
+    {(char *)"clear_errors", (PyCFunction)MGLContext_clear_errors, METH_NOARGS},
 
     {(char *)"_get_ubo_binding", (PyCFunction)MGLContext_get_ubo_binding, METH_VARARGS},
     {(char *)"_set_ubo_binding", (PyCFunction)MGLContext_set_ubo_binding, METH_VARARGS},

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -8334,6 +8334,8 @@ static PyObject * MGLContext_get_error(MGLContext * self, void * closure) {
             return PyUnicode_FromFormat("GL_STACK_UNDERFLOW");
         case GL_STACK_OVERFLOW:
             return PyUnicode_FromFormat("GL_STACK_OVERFLOW");
+        case GL_CONTEXT_LOST:
+            return PyUnicode_FromFormat("GL_CONTEXT_LOST");
     }
     return PyUnicode_FromFormat("GL_UNKNOWN_ERROR");
 }


### PR DESCRIPTION
This PR improves interoperability with other OpenGL libraries (either native or Python, doesn't matter) by providing a way to clear outstanding OpenGL errors, so that other libraries don't accidentally report errors originating from `moderngl` (or vice versa).

I also added `GL_CONTEXT_LOST` to `MGLContext_get_error` so that it could be accurately reported to Python-level code.

My use case involves a [libretro frontend](https://github.com/JesseTG/libretro.py) I'm writing. There are two specific problems I'm solving or anticipating:

1. I use PyOpenGL to fill in for features that `moderngl` doesn't yet support, like [the OpenGL debugging APIs](https://www.khronos.org/opengl/wiki/Debug_Output). PyOpenGL was raising an exception that made no sense; it turns out that the underlying error actually came from a `moderngl` API call that used multiple OpenGL functions under the hood. Since it didn't call `glGetError`, the global error state bled into PyOpenGL.
2. libretro.py supports loading libretro cores (i.e. ports of emulators or games) that may use OpenGL for rendering. The same "bleeding" of error state could occur here, except it would be harder to detect because libretro cores don't throw Python exceptions.