### PR TITLE
Add support for debug labels

### DIFF
--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -2825,14 +2825,6 @@ class Query:
     extra: Any
     """Attribute for storing user defined objects"""
 
-    label: str | None
-    """
-    A human-readable name for this object,
-    intended for debugging tools.
-    Will be set or fetched with OpenGL label calls if available,
-    or kept within the Python object if not.
-    """
-
     def __enter__(self): ...
     def __exit__(self, *args: Tuple[Any]): ...
 

--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -436,6 +436,14 @@ class Buffer:
     This values is provided for debug purposes only.
     """
 
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
+    """
+
     def write(self, data: Any, offset: int = 0) -> None:
         """
         Write the content.
@@ -651,6 +659,14 @@ class ComputeShader:
     The internal OpenGL object.
 
     This values is provided for debug purposes only.
+    """
+
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
     """
 
     def __getitem__(self, key: str) -> Union[Uniform, UniformBlock, StorageBlock]:
@@ -2497,6 +2513,14 @@ class Framebuffer:
     This values is provided for debug purposes only.
     """
 
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
+    """
+
     def clear(
         self,
         red: float = 0.0,
@@ -2737,6 +2761,15 @@ class Program:
     This values is provided for debug purposes only.
     """
 
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
+    """
+
+
     def get(self, key: str, default: Any) -> Union[Uniform, UniformBlock, Attribute, Varying]:
         """
         Returns a Uniform, UniformBlock, Attribute or Varying.
@@ -2792,6 +2825,14 @@ class Query:
     extra: Any
     """Attribute for storing user defined objects"""
 
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
+    """
+
     def __enter__(self): ...
     def __exit__(self, *args: Tuple[Any]): ...
 
@@ -2845,6 +2886,14 @@ class Renderbuffer:
     The internal OpenGL object.
 
     This values is provided for debug purposes only.
+    """
+
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
     """
 
     def release(self) -> None:
@@ -3007,6 +3056,14 @@ class Sampler:
     The internal OpenGL object.
 
     This values is provided for debug purposes only.
+    """
+
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
     """
 
     def use(self, location: int = 0) -> None:
@@ -3183,6 +3240,14 @@ class Texture3D:
     The internal OpenGL object.
 
     This values is provided for debug purposes only.
+    """
+
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
     """
 
     def read(self, alignment: int = 1) -> bytes:
@@ -3490,6 +3555,14 @@ class TextureArray:
     The internal OpenGL object.
 
     This values is provided for debug purposes only.
+    """
+
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
     """
 
     def read(self, alignment: int = 1) -> bytes:
@@ -3816,6 +3889,14 @@ class TextureCube:
     The internal OpenGL object.
 
     This values is provided for debug purposes only.
+    """
+
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
     """
 
     def read(self, face: int, alignment: int = 1) -> bytes:
@@ -4180,6 +4261,14 @@ class Texture:
     This values is provided for debug purposes only.
     """
 
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
+    """
+
     def read(self, level: int = 0, alignment: int = 1) -> bytes:
         """
         Read the pixel data as bytes into system memory.
@@ -4441,6 +4530,14 @@ class VertexArray:
     The internal OpenGL object.
 
     This values is provided for debug purposes only.
+    """
+
+    label: str | None
+    """
+    A human-readable name for this object,
+    intended for debugging tools.
+    Will be set or fetched with OpenGL label calls if available,
+    or kept within the Python object if not.
     """
 
     def render(

--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -1339,6 +1339,9 @@ class Context:
     max_texture_units: int
     """The max texture units."""
 
+    max_label_length: int | None
+    """The max label length. May be None if not supported."""
+
     max_anisotropy: float
     """The maximum value supported for anisotropic filtering."""
 

--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -1522,6 +1522,9 @@ class Context:
     fbo: Framebuffer
     """The active framebuffer. Set every time :py:meth:`Framebuffer.use()` is called."""
 
+    supports_labels: bool
+    """True if this context supports object labels via OpenGL 4.3, KHR_debug, or EXT_debug_label."""
+
     def clear(
         self,
         red: float = 0.0,

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -1486,6 +1486,19 @@ class Context:
         return self._extensions
 
     @property
+    def supports_labels(self):
+        if self.version_code >= 430:
+            return True
+
+        if "GL_KHR_debug" in self.extensions:
+            return True
+
+        if "EXT_debug_label" in self.extensions:
+            return True
+
+        return False
+
+    @property
     def info(self):
         if self._info is None:
             self._info = self.mglo.info

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -22,6 +22,16 @@ class _store:
     default_context = None
 
 
+# OpenGL Object type constants
+_BUFFER = 0x82E0
+_PROGRAM = 0x82E2
+_QUERY = 0x82E3
+_SAMPLER = 0x82E6
+_TEXTURE = 0x1702
+_VERTEX_ARRAY = 0x8074
+_FRAMEBUFFER = 0x8D40
+_RENDERBUFFER = 0x8D41
+
 class Buffer:
     def __init__(self):
         self.mglo = None
@@ -57,26 +67,19 @@ class Buffer:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_BUFFER, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_BUFFER, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def write(self, data, offset=0):
         self.mglo.write(data, offset)
@@ -211,26 +214,19 @@ class ComputeShader:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_PROGRAM, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_PROGRAM, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
 
 class Framebuffer:
@@ -333,26 +329,19 @@ class Framebuffer:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_FRAMEBUFFER, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_FRAMEBUFFER, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def clear(self, red=0.0, green=0.0, blue=0.0, alpha=0.0, depth=1.0, viewport=None, color=None):
         if color is not None:
@@ -452,26 +441,19 @@ class Program:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_PROGRAM, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_PROGRAM, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def get(self, key, default):
         return self._members.get(key, default)
@@ -540,26 +522,19 @@ class Renderbuffer:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_RENDERBUFFER, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_RENDERBUFFER, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def release(self):
         if not isinstance(self.mglo, InvalidObject):
@@ -675,26 +650,19 @@ class Sampler:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_SAMPLER, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_SAMPLER, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def assign(self, index):
         return (self, index)
@@ -845,26 +813,19 @@ class Texture:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_TEXTURE, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_TEXTURE, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def read(self, level=0, alignment=1):
         return self.mglo.read(level, alignment)
@@ -992,26 +953,19 @@ class Texture3D:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_TEXTURE, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_TEXTURE, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def read(self, alignment=1):
         return self.mglo.read(alignment)
@@ -1123,26 +1077,19 @@ class TextureCube:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_TEXTURE, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_TEXTURE, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def read(self, face, alignment=1):
         return self.mglo.read(face, alignment)
@@ -1271,26 +1218,19 @@ class TextureArray:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_TEXTURE, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_TEXTURE, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def read(self, alignment=1):
         return self.mglo.read(alignment)
@@ -1400,26 +1340,19 @@ class VertexArray:
     @property
     def label(self):
         if self.ctx.supports_labels:
-            return self.mglo.label
+            return self.ctx.mglo.get_label(_VERTEX_ARRAY, self._glo)
         else:
             return self._label
 
     @label.setter
     def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+        if not (isinstance(value, str) or value is None):
+            raise TypeError(f"Expected value to be a str or None, got {type(value).__name__}")
 
         if self.ctx.supports_labels:
-            self.mglo.label = value
+            self.ctx.mglo.set_label(_VERTEX_ARRAY, self._glo, value)
         else:
             self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
 
     def render(self, mode=None, vertices=-1, first=0, instances=-1):
         if mode is None:
@@ -1702,6 +1635,10 @@ class Context:
     @property
     def max_texture_units(self):
         return self.mglo.max_texture_units
+
+    @property
+    def max_label_length(self):
+        return self.mglo.max_label_length
 
     @property
     def default_texture_unit(self):

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -30,6 +30,7 @@ class Buffer:
         self._glo = None
         self.ctx = None
         self.extra = None
+        self._label = None # Used only if no OpenGL label functions are available
         raise TypeError()
 
     def __del__(self):
@@ -52,6 +53,30 @@ class Buffer:
     @property
     def glo(self):
         return self._glo
+
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
 
     def write(self, data, offset=0):
         self.mglo.write(data, offset)
@@ -114,6 +139,7 @@ class Query:
         self.crender = None
         self.ctx = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __enter__(self):
@@ -135,6 +161,30 @@ class Query:
     def elapsed(self):
         return self.mglo.elapsed
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
 
 class ComputeShader:
     def __init__(self):
@@ -143,6 +193,7 @@ class ComputeShader:
         self._glo = None
         self.ctx = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -181,6 +232,30 @@ class ComputeShader:
             self.mglo.release()
             self.mglo = InvalidObject()
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
 
 class Framebuffer:
     def __init__(self):
@@ -193,6 +268,7 @@ class Framebuffer:
         self.ctx = None
         self._is_reference = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -278,6 +354,30 @@ class Framebuffer:
     def glo(self):
         return self._glo
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
     def clear(self, red=0.0, green=0.0, blue=0.0, alpha=0.0, depth=1.0, viewport=None, color=None):
         if color is not None:
             red, green, blue, alpha, *_ = tuple(color) + (0.0, 0.0, 0.0, 0.0)
@@ -328,6 +428,7 @@ class Program:
         self._attribute_types = None
         self.ctx = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -372,6 +473,30 @@ class Program:
     def glo(self):
         return self._glo
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
     def get(self, key, default):
         return self._members.get(key, default)
 
@@ -392,6 +517,7 @@ class Renderbuffer:
         self._glo = None
         self.ctx = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -435,6 +561,30 @@ class Renderbuffer:
     def glo(self):
         return self._glo
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
     def release(self):
         if not isinstance(self.mglo, InvalidObject):
             self.mglo.release()
@@ -448,6 +598,7 @@ class Sampler:
         self.ctx = None
         self.extra = None
         self.texture = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -544,6 +695,31 @@ class Sampler:
     def max_lod(self, value):
         self.mglo.max_lod = value
 
+
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
     def assign(self, index):
         return (self, index)
 
@@ -598,6 +774,7 @@ class Texture:
         self._glo = None
         self.ctx = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -689,6 +866,30 @@ class Texture:
     def glo(self):
         return self._glo
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
     def read(self, level=0, alignment=1):
         return self.mglo.read(level, alignment)
 
@@ -732,6 +933,7 @@ class Texture3D:
         self._glo = None
         self.ctx = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -811,6 +1013,30 @@ class Texture3D:
     def glo(self):
         return self._glo
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
     def read(self, alignment=1):
         return self.mglo.read(alignment)
 
@@ -854,6 +1080,7 @@ class TextureCube:
         self._glo = None
         self.ctx = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -917,6 +1144,30 @@ class TextureCube:
     def glo(self):
         return self._glo
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
     def read(self, face, alignment=1):
         return self.mglo.read(face, alignment)
 
@@ -961,6 +1212,7 @@ class TextureArray:
         self._glo = None
         self.ctx = None
         self.extra = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -1040,6 +1292,30 @@ class TextureArray:
     def glo(self):
         return self._glo
 
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
+
     def read(self, alignment=1):
         return self.mglo.read(alignment)
 
@@ -1085,6 +1361,7 @@ class VertexArray:
         self.ctx = None
         self.extra = None
         self.scope = None
+        self._label = None
         raise TypeError()
 
     def __del__(self):
@@ -1143,6 +1420,30 @@ class VertexArray:
     @property
     def glo(self):
         return self._glo
+
+    @property
+    def label(self):
+        if self.ctx.supports_labels:
+            return self.mglo.label
+        else:
+            return self._label
+
+    @label.setter
+    def label(self, value):
+        if not isinstance(value, str):
+            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
+
+        if self.ctx.supports_labels:
+            self.mglo.label = value
+        else:
+            self._label = value
+
+    @label.deleter
+    def label(self):
+        if self.ctx.supports_labels:
+            self.mglo.label = None
+        else:
+            self._label = None
 
     def render(self, mode=None, vertices=-1, first=0, instances=-1):
         if mode is None:

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -161,30 +161,6 @@ class Query:
     def elapsed(self):
         return self.mglo.elapsed
 
-    @property
-    def label(self):
-        if self.ctx.supports_labels:
-            return self.mglo.label
-        else:
-            return self._label
-
-    @label.setter
-    def label(self, value):
-        if not isinstance(value, str):
-            raise TypeError(f"Expected value to be a str, got {type(value).__name__}")
-
-        if self.ctx.supports_labels:
-            self.mglo.label = value
-        else:
-            self._label = value
-
-    @label.deleter
-    def label(self):
-        if self.ctx.supports_labels:
-            self.mglo.label = None
-        else:
-            self._label = None
-
 
 class ComputeShader:
     def __init__(self):

--- a/src/gl_methods.hpp
+++ b/src/gl_methods.hpp
@@ -780,8 +780,8 @@ struct GLMethods {
     // PFNGLGETPERFMONITORCOUNTERDATAAMDPROC GetPerfMonitorCounterDataAMD;
     // PFNGLEGLIMAGETARGETTEXSTORAGEEXTPROC EGLImageTargetTexStorageEXT;
     // PFNGLEGLIMAGETARGETTEXTURESTORAGEEXTPROC EGLImageTargetTextureStorageEXT;
-    // PFNGLLABELOBJECTEXTPROC LabelObjectEXT;
-    // PFNGLGETOBJECTLABELEXTPROC GetObjectLabelEXT;
+    PFNGLLABELOBJECTEXTPROC LabelObjectEXT;
+    PFNGLGETOBJECTLABELEXTPROC GetObjectLabelEXT;
     // PFNGLINSERTEVENTMARKEREXTPROC InsertEventMarkerEXT;
     // PFNGLPUSHGROUPMARKEREXTPROC PushGroupMarkerEXT;
     // PFNGLPOPGROUPMARKEREXTPROC PopGroupMarkerEXT;
@@ -2079,8 +2079,8 @@ GLMethods load_gl_methods(PyObject * loader) {
     // load(GetPerfMonitorCounterDataAMD);
     // load(EGLImageTargetTexStorageEXT);
     // load(EGLImageTargetTextureStorageEXT);
-    // load(LabelObjectEXT);
-    // load(GetObjectLabelEXT);
+    load(LabelObjectEXT);
+    load(GetObjectLabelEXT);
     // load(InsertEventMarkerEXT);
     // load(PushGroupMarkerEXT);
     // load(PopGroupMarkerEXT);

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "gl_methods.hpp"
@@ -7198,7 +7199,7 @@ static PyObject * MGLContext_set_label(MGLContext * self, PyObject * args) {
     const char* label = NULL;
     Py_ssize_t label_length = 0;
 
-    int args_ok = PyArg_ParseTuple(args, "(IIz#)", &type, &object, &label, &label_length);
+    int args_ok = PyArg_ParseTuple(args, "IIz#", &type, &object, &label, &label_length);
     if (!args_ok) {
         return NULL;
     }
@@ -7259,7 +7260,7 @@ static PyObject * MGLContext_get_label(MGLContext * ctx, PyObject * args) {
     GLenum type = 0;
     GLuint object = 0;
 
-    int args_ok = PyArg_ParseTuple(args, "(II)", &type, &object);
+    int args_ok = PyArg_ParseTuple(args, "II", &type, &object);
     if (!args_ok) {
         return NULL;
     }

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -1389,14 +1389,6 @@ static PyObject * MGLBuffer_size(MGLBuffer * self, PyObject * args) {
     return PyLong_FromSsize_t(self->size);
 }
 
-static PyObject * MGLBuffer_get_label(MGLBuffer * self, void * closure) {
-    return get_label(self->context, GL_BUFFER, self->buffer_obj);
-}
-
-static int MGLBuffer_set_label(MGLBuffer * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_BUFFER, self->buffer_obj, value);
-}
-
 static int MGLBuffer_tp_as_buffer_get_view(MGLBuffer * self, Py_buffer * view, int flags) {
     int access = (flags == PyBUF_SIMPLE) ? GL_MAP_READ_BIT : (GL_MAP_READ_BIT | GL_MAP_WRITE_BIT);
 
@@ -2178,14 +2170,6 @@ static PyObject * MGLFramebuffer_get_bits(MGLFramebuffer * self, void * closure)
     return result;
 }
 
-static PyObject * MGLFramebuffer_get_label(MGLFramebuffer * self, void * closure) {
-    return get_label(self->context, GL_FRAMEBUFFER, self->framebuffer_obj);
-}
-
-static int MGLFramebuffer_set_label(MGLFramebuffer * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_FRAMEBUFFER, self->framebuffer_obj, value);
-}
-
 static PyObject * MGLContext_program(MGLContext * self, PyObject * args) {
     PyObject * shaders[6];
     PyObject * varyings_arg;
@@ -2680,14 +2664,6 @@ static PyObject * MGLProgram_release(MGLProgram * self, PyObject * args) {
     Py_RETURN_NONE;
 }
 
-static PyObject * MGLProgram_get_label(MGLProgram * self, void * closure) {
-    return get_label(self->context, GL_PROGRAM, self->program_obj);
-}
-
-static int MGLProgram_set_label(MGLProgram * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_PROGRAM, self->program_obj, value);
-}
-
 static PyObject * MGLContext_query(MGLContext * self, PyObject * args) {
     int samples_passed;
     int any_samples_passed;
@@ -2912,14 +2888,6 @@ static PyObject * MGLRenderbuffer_release(MGLRenderbuffer * self, PyObject * arg
 
     Py_DECREF(self);
     Py_RETURN_NONE;
-}
-
-static PyObject * MGLRenderbuffer_get_label(MGLRenderbuffer * self, void * closure) {
-    return get_label(self->context, GL_RENDERBUFFER, self->renderbuffer_obj);
-}
-
-static int MGLRenderbuffer_set_label(MGLRenderbuffer * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_RENDERBUFFER, self->renderbuffer_obj, value);
 }
 
 static PyObject * MGLContext_sampler(MGLContext * self, PyObject * args) {
@@ -3227,14 +3195,6 @@ static int MGLSampler_set_max_lod(MGLSampler * self, PyObject * value, void * cl
     gl.SamplerParameterf(self->sampler_obj, GL_TEXTURE_MAX_LOD, self->max_lod);
 
     return 0;
-}
-
-static PyObject * MGLSampler_get_label(MGLSampler * self, void * closure) {
-    return get_label(self->context, GL_SAMPLER, self->sampler_obj);
-}
-
-static int MGLSampler_set_label(MGLSampler * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_SAMPLER, self->sampler_obj, value);
 }
 
 static int parse_texture_binding(PyObject * arg, TextureBinding * value) {
@@ -4618,14 +4578,6 @@ static int MGLTexture_set_anisotropy(MGLTexture * self, PyObject * value, void *
     return 0;
 }
 
-static PyObject * MGLTexture_get_label(MGLTexture * self, void * closure) {
-    return get_label(self->context, GL_TEXTURE, self->texture_obj);
-}
-
-static int MGLTexture_set_label(MGLTexture * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_TEXTURE, self->texture_obj, value);
-}
-
 static PyObject * MGLContext_texture3d(MGLContext * self, PyObject * args) {
     int width;
     int height;
@@ -5249,14 +5201,6 @@ static int MGLTexture3D_set_swizzle(MGLTexture3D * self, PyObject * value, void 
     }
 
     return 0;
-}
-
-static PyObject * MGLTexture3D_get_label(MGLTexture3D * self, void * closure) {
-    return get_label(self->context, GL_TEXTURE, self->texture_obj);
-}
-
-static int MGLTexture3D_set_label(MGLTexture3D * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_TEXTURE, self->texture_obj, value);
 }
 
 static PyObject * MGLContext_texture_array(MGLContext * self, PyObject * args) {
@@ -5898,14 +5842,6 @@ static int MGLTextureArray_set_anisotropy(MGLTextureArray * self, PyObject * val
     gl.TexParameterf(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAX_ANISOTROPY, self->anisotropy);
 
     return 0;
-}
-
-static PyObject * MGLTextureArray_get_label(MGLTextureArray * self, void * closure) {
-    return get_label(self->context, GL_TEXTURE, self->texture_obj);
-}
-
-static int MGLTextureArray_set_label(MGLTextureArray * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_TEXTURE, self->texture_obj, value);
 }
 
 static PyObject * MGLContext_texture_cube(MGLContext * self, PyObject * args) {
@@ -6683,14 +6619,6 @@ static int MGLTextureCube_set_anisotropy(MGLTextureCube * self, PyObject * value
     return 0;
 }
 
-static PyObject * MGLTextureCube_get_label(MGLTextureCube * self, void * closure) {
-    return get_label(self->context, GL_TEXTURE, self->texture_obj);
-}
-
-static int MGLTextureCube_set_label(MGLTextureCube * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_TEXTURE, self->texture_obj, value);
-}
-
 static PyObject * MGLContext_vertex_array(MGLContext * self, PyObject * args) {
     MGLProgram * program;
     PyObject * content;
@@ -7262,91 +7190,121 @@ static int MGLVertexArray_set_instances(MGLVertexArray * self, PyObject * value,
     return 0;
 }
 
-static PyObject * MGLVertexArray_get_label(MGLVertexArray * self, void * closure) {
-    return get_label(self->context, GL_VERTEX_ARRAY, self->vertex_array_obj);
-}
+static PyObject * MGLContext_set_label(MGLContext * self, PyObject * args) {
+    const GLMethods & gl = self->gl;
 
-static int MGLVertexArray_set_label(MGLVertexArray * self, PyObject * value, void * closure) {
-    return set_label(self->context, GL_VERTEX_ARRAY, self->vertex_array_obj, value);
-}
+    GLenum type = 0;
+    GLuint object = 0;
+    const char* label = NULL;
+    Py_ssize_t label_length = 0;
 
-static int set_label(MGLContext * ctx, GLenum type, GLuint object, PyObject * value) {
-    const GLMethods & gl = ctx->gl;
-    const char * label = PyUnicode_AsUTF8(value);
-    if (!label) {
-        MGLError_Set("label must be a string");
-        return -1;
+    int args_ok = PyArg_ParseTuple(args, "(IIz#)", &type, &object, &label, &label_length);
+    if (!args_ok) {
+        return NULL;
     }
 
     if (gl.ObjectLabel) {
         // OpenGL core 4.3
-        gl.ObjectLabel(type, object, -1, label);
+
+        if (label_length > self->max_label_length) {
+            MGLError_Set("Context's max label length is %d, got one of length %d", self->max_label_length, label_length);
+            return NULL;
+        }
+
+        gl.ObjectLabel(type, object, label_length, label);
         GLenum error = gl.GetError();
         if (error != GL_NO_ERROR) {
             MGLError_Set("glObjectLabel failed with 0x%x", error);
-            return -1;
+            return NULL;
+        }
+    }
+    else if (gl.LabelObjectEXT) {
+        // GL_EXT_debug_label
+        switch (type) {
+            // GL_EXT_debug_label defines its own type constants for some (not all!) OpenGL types,
+            // and these values are not equal to the standard ones
+            case GL_BUFFER:
+                type = GL_BUFFER_OBJECT_EXT;
+                break;
+            case GL_PROGRAM:
+                type = GL_PROGRAM_OBJECT_EXT;
+                break;
+            case GL_VERTEX_ARRAY:
+                type = GL_VERTEX_ARRAY_OBJECT_EXT;
+                break;
+            case GL_QUERY:
+                type = GL_QUERY_OBJECT_EXT;
+                break;
         }
 
-        return 0;
-    }
-
-    if (gl.LabelObjectEXT) {
-        // GL_EXT_debug_label
-        gl.LabelObjectEXT(type, object, -1, label);
+        // GL_EXT_debug_label doesn't define a max label length
+        gl.LabelObjectEXT(type, object, label_length, label);
         GLenum error = gl.GetError();
         if (error != GL_NO_ERROR) {
             MGLError_Set("glLabelObjectEXT failed with 0x%x", error);
-            return -1;
+            return NULL;
         }
-
-        return 0;
     }
 
     // Are there any environments that support GL_KHR_debug
     // but not standard glObjectLabel or GL_EXT_debug_label?
     // If so, we should fall back to it
 
-    MGLError_Set("no label support available");
-    return -1;
+    Py_RETURN_NONE;
 }
 
-static PyObject * get_label(MGLContext * ctx, GLenum type, GLuint object) {
+static PyObject * MGLContext_get_label(MGLContext * ctx, PyObject * args) {
     const GLMethods & gl = ctx->gl;
 
-    char label[1024];
-    GLsizei labelLength = 0;
+    GLenum type = 0;
+    GLuint object = 0;
+
+    int args_ok = PyArg_ParseTuple(args, "(II)", &type, &object);
+    if (!args_ok) {
+        return NULL;
+    }
+
+    int label_buffer_length = ctx->max_label_length + 1;
+    char * label = new char[label_buffer_length];
+    GLsizei label_length = 0;
     if (gl.GetObjectLabel) {
         // OpenGL core 4.3
 
-        gl.GetObjectLabel(type, object, sizeof(label), &labelLength, label);
+        gl.GetObjectLabel(type, object, label_buffer_length, &label_length, label);
         GLenum error = gl.GetError();
         if (error != GL_NO_ERROR) {
+            delete[] label;
             MGLError_Set("glGetObjectLabel failed with 0x%x", error);
             return NULL;
         }
-
-        return PyUnicode_FromStringAndSize(label, labelLength);
     }
-
-    if (gl.GetObjectLabelEXT) {
+    else if (gl.GetObjectLabelEXT) {
         // EXT_debug_label
 
-        gl.GetObjectLabelEXT(type, object, sizeof(label), &labelLength, label);
+        gl.GetObjectLabelEXT(type, object, label_buffer_length, &label_length, label);
         GLenum error = gl.GetError();
         if (error != GL_NO_ERROR) {
+            delete[] label;
             MGLError_Set("glGetObjectLabelEXT failed with 0x%x", error);
             return NULL;
         }
-
-        return PyUnicode_FromStringAndSize(label, labelLength);
     }
 
     // Are there any environments that support GL_KHR_debug
     // but not standard glObjectLabel or GL_EXT_debug_label?
     // If so, we should fall back to it
 
-    MGLError_Set("no label support available");
-    return NULL;
+    PyObject * result = label_length > 0 ? PyUnicode_FromStringAndSize(label, label_length) : NULL;
+    delete[] label;
+
+    if (result) {
+        return result;
+    } else {
+        Py_RETURN_NONE;
+    }
+    // If labels aren't supported, this method will return None;
+    // clients that want to know if labels are supported should
+    // use the version number or extension list
 }
 
 static PyObject * MGLContext_enable_only(MGLContext * self, PyObject * args) {
@@ -8374,7 +8332,12 @@ static PyObject * MGLContext_get_max_anisotropy(MGLContext * self, void * closur
 }
 
 static PyObject * MGLContext_get_max_label_length(MGLContext * self, void * closure) {
-    return PyLong_FromLong(self->max_label_length);
+    if (self->max_label_length > 0) {
+        return PyLong_FromLong(self->max_label_length);
+    }
+    else {
+        Py_RETURN_NONE;
+    }
 }
 
 static MGLFramebuffer * MGLContext_get_fbo(MGLContext * self, void * closure) {
@@ -9003,7 +8966,6 @@ static PyMethodDef MGL_module_methods[] = {
 };
 
 static PyGetSetDef MGLBuffer_getset[] = {
-    {(char *)"label", (getter)MGLBuffer_get_label, (setter)MGLBuffer_set_label},
     {},
 };
 
@@ -9114,8 +9076,6 @@ static PyGetSetDef MGLFramebuffer_getset[] = {
     {(char *)"depth_mask", (getter)MGLFramebuffer_get_depth_mask, (setter)MGLFramebuffer_set_depth_mask},
 
     {(char *)"bits", (getter)MGLFramebuffer_get_bits, NULL},
-
-    {(char *)"label", (getter)MGLFramebuffer_get_label, (setter)MGLFramebuffer_set_label},
     {},
 };
 
@@ -9128,7 +9088,6 @@ static PyMethodDef MGLFramebuffer_methods[] = {
 };
 
 static PyGetSetDef MGLProgram_getset[] = {
-    {(char *)"label", (getter)MGLProgram_get_label, (setter)MGLProgram_set_label},
     {},
 };
 
@@ -9156,7 +9115,6 @@ static PyMethodDef MGLQuery_methods[] = {
 };
 
 static PyGetSetDef MGLRenderbuffer_getset[] = {
-    {(char *)"label", (getter)MGLRenderbuffer_get_label, (setter)MGLRenderbuffer_set_label},
     {},
 };
 
@@ -9175,7 +9133,6 @@ static PyGetSetDef MGLSampler_getset[] = {
     {(char *)"border_color", (getter)MGLSampler_get_border_color, (setter)MGLSampler_set_border_color},
     {(char *)"min_lod", (getter)MGLSampler_get_min_lod, (setter)MGLSampler_set_min_lod},
     {(char *)"max_lod", (getter)MGLSampler_get_max_lod, (setter)MGLSampler_set_max_lod},
-    {(char *)"label", (getter)MGLSampler_get_label, (setter)MGLSampler_set_label},
     {},
 };
 
@@ -9200,7 +9157,6 @@ static PyGetSetDef MGLTexture_getset[] = {
     {(char *)"swizzle", (getter)MGLTexture_get_swizzle, (setter)MGLTexture_set_swizzle},
     {(char *)"compare_func", (getter)MGLTexture_get_compare_func, (setter)MGLTexture_set_compare_func},
     {(char *)"anisotropy", (getter)MGLTexture_get_anisotropy, (setter)MGLTexture_set_anisotropy},
-    {(char *)"label", (getter)MGLTexture_get_label, (setter)MGLTexture_set_label},
     {},
 };
 
@@ -9222,7 +9178,6 @@ static PyGetSetDef MGLTexture3D_getset[] = {
     {(char *)"repeat_z", (getter)MGLTexture3D_get_repeat_z, (setter)MGLTexture3D_set_repeat_z},
     {(char *)"filter", (getter)MGLTexture3D_get_filter, (setter)MGLTexture3D_set_filter},
     {(char *)"swizzle", (getter)MGLTexture3D_get_swizzle, (setter)MGLTexture3D_set_swizzle},
-    {(char *)"label", (getter)MGLTexture3D_get_label, (setter)MGLTexture3D_set_label},
     {},
 };
 
@@ -9244,7 +9199,6 @@ static PyGetSetDef MGLTextureArray_getset[] = {
     {(char *)"filter", (getter)MGLTextureArray_get_filter, (setter)MGLTextureArray_set_filter},
     {(char *)"swizzle", (getter)MGLTextureArray_get_swizzle, (setter)MGLTextureArray_set_swizzle},
     {(char *)"anisotropy", (getter)MGLTextureArray_get_anisotropy, (setter)MGLTextureArray_set_anisotropy},
-    {(char *)"label", (getter)MGLTextureArray_get_label, (setter)MGLTextureArray_set_label},
     {},
 };
 
@@ -9265,7 +9219,6 @@ static PyGetSetDef MGLTextureCube_getset[] = {
     {(char *)"swizzle", (getter)MGLTextureCube_get_swizzle, (setter)MGLTextureCube_set_swizzle},
     {(char *)"compare_func", (getter)MGLTextureCube_get_compare_func, (setter)MGLTextureCube_set_compare_func},
     {(char *)"anisotropy", (getter)MGLTextureCube_get_anisotropy, (setter)MGLTextureCube_set_anisotropy},
-    {(char *)"label", (getter)MGLTextureCube_get_label, (setter)MGLTextureCube_set_label},
     {},
 };
 
@@ -9294,7 +9247,6 @@ static PyGetSetDef MGLVertexArray_getset[] = {
     {(char *)"index_buffer", NULL, (setter)MGLVertexArray_set_index_buffer},
     {(char *)"vertices", (getter)MGLVertexArray_get_vertices, (setter)MGLVertexArray_set_vertices},
     {(char *)"instances", (getter)MGLVertexArray_get_instances, (setter)MGLVertexArray_set_instances},
-    {(char *)"label", (getter)MGLVertexArray_get_label, (setter)MGLVertexArray_set_label},
     {},
 };
 

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -111,7 +111,6 @@ struct MGLContext {
     float polygon_offset_units;
     GLMethods gl;
     bool released;
-    bool has_khr_debug;
 };
 
 struct Rect {
@@ -8698,11 +8697,7 @@ static PyObject * MGLContext_get_info(MGLContext * self, void * closure) {
         set_info_int64(self, info, "GL_MAX_SHADER_STORAGE_BLOCK_SIZE", GL_MAX_SHADER_STORAGE_BLOCK_SIZE);
     }
 
-    if (self->has_khr_debug) {
-        // set_info_int(self, info, "GL_MAX_LABEL_LENGTH_KHR", GL_MAX_LABEL_LENGTH_KHR);
-    }
-
-    // EXT_debug_label has no equivalent
+    // GL_EXT_debug_label doesn't define a MAX_LABEL_LENGTH constant
 
     return info;
 }
@@ -8858,16 +8853,11 @@ static PyObject * create_context(PyObject * self, PyObject * args, PyObject * kw
 
     // Load extensions
     int num_extensions = 0;
-    ctx->has_khr_debug = false;
     gl.GetIntegerv(GL_NUM_EXTENSIONS, &num_extensions);
     ctx->extensions = PySet_New(NULL);
 
     for(int i = 0; i < num_extensions; i++) {
         const char * ext = (const char *)gl.GetStringi(GL_EXTENSIONS, i);
-        if (!ctx->has_khr_debug && (strcmp(ext, "GL_KHR_debug") == 0)) {
-            // If we haven't found GL_KHR_debug yet, see if this is the one...
-            ctx->has_khr_debug = true;
-        }
         PyObject * ext_name = PyUnicode_FromString(ext);
         PySet_Add(ctx->extensions, ext_name);
     }

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -111,6 +111,7 @@ struct MGLContext {
     float polygon_offset_units;
     GLMethods gl;
     bool released;
+    bool has_khr_debug;
 };
 
 struct Rect {
@@ -8689,11 +8690,16 @@ static PyObject * create_context(PyObject * self, PyObject * args, PyObject * kw
 
     // Load extensions
     int num_extensions = 0;
+    ctx->has_khr_debug = false;
     gl.GetIntegerv(GL_NUM_EXTENSIONS, &num_extensions);
     ctx->extensions = PySet_New(NULL);
 
     for(int i = 0; i < num_extensions; i++) {
         const char * ext = (const char *)gl.GetStringi(GL_EXTENSIONS, i);
+        if (!ctx->has_khr_debug && (strcmp(ext, "GL_KHR_debug") == 0)) {
+            // If we haven't found GL_KHR_debug yet, see if this is the one...
+            ctx->has_khr_debug = true;
+        }
         PyObject * ext_name = PyUnicode_FromString(ext);
         PySet_Add(ctx->extensions, ext_name);
     }

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -94,6 +94,7 @@ struct MGLContext {
     int max_integer_samples;
     int max_color_attachments;
     int max_texture_units;
+    int max_label_length;
     int default_texture_unit;
     float max_anisotropy;
     int enable_flags;
@@ -8372,6 +8373,10 @@ static PyObject * MGLContext_get_max_anisotropy(MGLContext * self, void * closur
     return PyFloat_FromDouble(self->max_anisotropy);
 }
 
+static PyObject * MGLContext_get_max_label_length(MGLContext * self, void * closure) {
+    return PyLong_FromLong(self->max_label_length);
+}
+
 static MGLFramebuffer * MGLContext_get_fbo(MGLContext * self, void * closure) {
     Py_INCREF(self->bound_framebuffer);
     return self->bound_framebuffer;
@@ -8886,6 +8891,9 @@ static PyObject * create_context(PyObject * self, PyObject * args, PyObject * kw
     gl.GetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, (GLint *)&ctx->max_texture_units);
     ctx->default_texture_unit = ctx->max_texture_units - 1;
 
+    ctx->max_label_length = 0;
+    gl.GetIntegerv(GL_MAX_LABEL_LENGTH, (GLint *)&ctx->max_label_length);
+
     ctx->max_anisotropy = 0.0;
     gl.GetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY, (GLfloat *)&ctx->max_anisotropy);
 
@@ -9080,6 +9088,7 @@ static PyGetSetDef MGLContext_getset[] = {
     {(char *)"max_integer_samples", (getter)MGLContext_get_max_integer_samples, NULL},
     {(char *)"max_texture_units", (getter)MGLContext_get_max_texture_units, NULL},
     {(char *)"max_anisotropy", (getter)MGLContext_get_max_anisotropy, NULL},
+    {(char *)"max_label_length", (getter)MGLContext_get_max_label_length, NULL},
 
     {(char *)"fbo", (getter)MGLContext_get_fbo, (setter)MGLContext_set_fbo},
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -90,3 +90,9 @@ def test_buffer_orphan_resize(ctx):
     buf.orphan(-100)
     assert buf.size == 100
     assert len(buf.read()) == 100
+
+
+def test_buffer_labels(ctx):
+    buf = ctx.buffer(reserve=1024)
+    buf.label = "test buffer"
+    assert buf.label == "test buffer"

--- a/tests/test_framebuffer.py
+++ b/tests/test_framebuffer.py
@@ -1,6 +1,7 @@
 
 def test_properties(ctx):
     fbo = ctx.simple_framebuffer((4, 4))
+    fbo.label = "my favorite fbo"
     assert fbo.size == (4, 4)
     assert fbo == fbo
     assert fbo.depth_mask is True
@@ -9,6 +10,7 @@ def test_properties(ctx):
     assert fbo.size == (4, 4)
     assert fbo.samples == 0
     assert fbo.glo > 0
+    assert fbo.label == "my favorite fbo"
 
     fbo.depth_mask = False
     assert fbo.depth_mask is False

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,32 @@
+import moderngl
+import pytest
+
+def test_error_when_label_is_too_long(ctx):
+    buf = ctx.buffer(reserve=1024)
+    max_label_length = ctx.max_label_length
+
+    with pytest.raises(moderngl.Error):
+        buf.label = "F" * (max_label_length + 1)
+
+
+def test_error_with_wrong_type(ctx):
+    buf = ctx.buffer(reserve=1024)
+
+    with pytest.raises(TypeError):
+        buf.label = 123
+
+
+def test_no_label_on_creation(ctx):
+    buf = ctx.buffer(reserve=1024)
+
+    assert buf.label is None
+
+
+def test_clearing_label(ctx):
+    buf = ctx.buffer(reserve=1024)
+    buf.label = "test buffer"
+    assert buf.label is not None
+
+    buf.label = None
+
+    assert buf.label is None

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -28,12 +28,15 @@ def test_program(ctx):
             }
         ''',
     )
+
+    program.label = "my favorite program"
     assert program.glo > 0
 
     assert 'vert' in program
     assert 'pos' in program
     assert 'scale' in program
     assert program.is_transform is False
+    assert program.label == "my favorite program"
 
     assert isinstance(program['vert'], moderngl.Attribute)
     assert isinstance(program['pos'], moderngl.Uniform)

--- a/tests/test_renderbuffer.py
+++ b/tests/test_renderbuffer.py
@@ -46,3 +46,9 @@ def test_renderbuffer_invalid_samples(ctx):
 
     with pytest.raises(Exception, match='samples is invalid'):
         ctx.renderbuffer((4, 4), samples=3)
+
+
+def test_renderbuffer_labels(ctx):
+    rbo = ctx.renderbuffer((4, 8))
+    rbo.label = "best renderbuffer ever"
+    assert rbo.label == "best renderbuffer ever"

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -69,3 +69,9 @@ def test_clear_samplers(ctx):
     ctx.clear_samplers(start=0, end=5)
     ctx.clear_samplers(start=5, end=10)
     ctx.clear_samplers(start=10, end=100)
+
+
+def test_sampler_labels(ctx):
+    sampler = ctx.sampler()
+    sampler.label = "sampler of excellence"
+    assert sampler.label == "sampler of excellence"

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -45,6 +45,9 @@ def test_texture_properties(ctx):
     assert tex.dtype == 'f1'
     assert tex.anisotropy == 0.0
 
+    tex.label = "wonderful texture"
+    assert tex.label == "wonderful texture"
+
     tex.anisotropy = ctx.max_anisotropy
     assert tex.anisotropy == ctx.max_anisotropy
     tex.build_mipmaps()

--- a/tests/test_texture_array.py
+++ b/tests/test_texture_array.py
@@ -39,6 +39,9 @@ def test_create(ctx):
     texture.build_mipmaps()
     assert texture.filter == (moderngl.LINEAR_MIPMAP_LINEAR, moderngl.LINEAR)
 
+    texture.label = "best texture array"
+    assert texture.label == "best texture array"
+
 
 def test_texture_default_filter(ctx):
     """Ensure default filter is correct"""

--- a/tests/test_texture_cube.py
+++ b/tests/test_texture_cube.py
@@ -25,6 +25,9 @@ def test_0(ctx):
     texture.anisotropy = ctx.max_anisotropy
     assert texture.anisotropy == ctx.max_anisotropy
 
+    texture.label = "six times the faces, six times the fun"
+    assert texture.label == "six times the faces, six times the fun"
+
 
 def test_1(ctx):
     faces = [

--- a/tests/test_texture_external.py
+++ b/tests/test_texture_external.py
@@ -25,3 +25,10 @@ def test_init_from_texture_and_params(ctx):
     assert ext.mglo != tex.mglo
     assert ext.ctx == ctx
     assert ext.extra == None
+
+    if ctx.supports_labels:
+        tex.label = "two objects, one texture"
+        assert tex.label == ext.label
+
+    # If the current context doesn't support labels,
+    # then labels will fall back to plain Python objects

--- a/tests/test_vertex_array.py
+++ b/tests/test_vertex_array.py
@@ -234,3 +234,20 @@ def test_4(ctx):
     vao.transform(vbo2, moderngl.POINTS, vertices=1)
     res = np.frombuffer(vbo2.read(), dtype='f4')
     npt.assert_almost_equal(res, [4.0, 0.0, 2.0, 0.0])
+
+
+def test_vao_labels(ctx):
+    prog = ctx.program(
+        vertex_shader="""
+        #version 330
+        in vec2 pos;
+        in vec2 velocity;
+        out vec2 out_pos;
+        void main() {
+            out_pos = pos + velocity;
+        }
+        """,
+    )
+    vao = ctx.vertex_array(prog, [])
+    vao.label = "My VAO"
+    assert vao.label == "My VAO"


### PR DESCRIPTION
This PR adds support for object labels for most objects exposed by moderngl. Here's how that works:

- If using OpenGL 4.3 or greater, standard `glObjectLabel` will be used.
- Otherwise if `GL_EXT_debug_label` is available, `glLabelObjectEXT` will be used.
- Otherwise no OpenGL label functionality will be used, but a `str` will be kept in the Python objects so that client code will work anyway.
- I wanted to include `GL_KHR_debug` in the fallbacks, but I was advised that this is likely unnecessary. So I just left a note in case the issue ever comes up again.

The only applicable object I didn't add label support for is `moderngl.Query`; since it's actually comprised of four [query objects](https://www.khronos.org/opengl/wiki/Query_Object), I couldn't decide on a suitable design. I was thinking about either exposing the labels individually or using one as a common prefix.