### PR TITLE
Multidraw, typehint & docs stubs, improved example

### DIFF
--- a/moderngl-stubs/__init__.pyi
+++ b/moderngl-stubs/__init__.pyi
@@ -733,7 +733,11 @@ class ComputeShader:
         """
     def run_indirect(self, buffer: Buffer, offset: int = 0) -> None:
         """
-        Run the compute shader.
+        Run the compute shader indirectly.
+
+        Args:
+            buffer (Buffer): Buffer with packed args (4 bytes (uint32) x & 4 bytes (uint32) y & 4 bytes (uint32) z).
+            offset: Offset in bytes to look for args inside the buffer.
         """
     def get(self, key: str, default: Any) -> Union[Uniform, UniformBlock, Attribute, Varying]:
         """
@@ -2821,6 +2825,35 @@ class Program:
 
         Returns:
             :py:class:`Uniform`, :py:class:`UniformBlock`, :py:class:`Attribute` or :py:class:`Varying`
+        """
+    def draw_mesh_tasks(self, first: int, count: int) -> None:
+        """
+        Dispatch mesh tasks (requires mesh and optionally task shader).
+
+        Args:
+            first: Index of the first shader workgroup to dispatch.
+            count: Number of workgroups to dispatch.
+        """
+    def draw_mesh_tasks_indirect(self, buffer: Buffer, offset: int = 0, drawcount: int = 1, stride: int = 0) -> None:
+        """
+        Dispatch mesh tasks indirectly (requires mesh and optionally task shader).
+
+        Args:
+            buffer (Buffer): Buffer with packed args (4 bytes (uint32) count & 4 bytes (uint32) first). Note that order in args structure is intentional due to inconsistencies in underlying API.
+            offset: Offset in bytes to look for args inside the buffer.
+            drawcount: Number of drawcalls to dispatch from buffer.
+            stride: Stride in bytes between structures inside the buffer.
+        """
+    def draw_mesh_tasks_indirect_count(self, buffer: Buffer, offset: int, drawcount_offset: int, maxdrawcount: int, stride: int = 0) -> None:
+        """
+        Dispatch mesh tasks indirectly (requires mesh and optionally task shader).
+
+        Args:
+            buffer (Buffer): Buffer with packed args (4 bytes (uint32) count & 4 bytes (uint32) first) and drawcounts (4 bytes (uint32) drawcount). Note that order in args structure is intentional due to inconsistencies in underlying API.
+            offset: Offset in bytes to look for args inside the buffer.
+            drawcount_offset: Offset in bytes to look for number of drawcalls inside the buffer.
+            maxdrawcount: Maximum number of drawcalls to dispatch from buffer.
+            stride: Stride in bytes between structures inside the buffer.
         """
     def release(self) -> None:
         """Release the ModernGL object."""

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -521,8 +521,11 @@ class Program:
     def draw_mesh_tasks(self, first, count):
         return self.mglo.draw_mesh_tasks(first, count)
 
-    def draw_mesh_tasks_indirect(self, buffer, offset=0):
-        return self.mglo.draw_mesh_tasks_indirect(buffer.mglo, offset)
+    def draw_mesh_tasks_indirect(self, buffer, offset=0, drawcount=1, stride=0):
+        return self.mglo.draw_mesh_tasks_indirect(buffer.mglo, offset, drawcount, stride)
+    
+    def draw_mesh_tasks_indirect_count(self, buffer, offset, drawcount_offset, maxdrawcount, stride=0):
+        return self.mglo.draw_mesh_tasks_indirect_count(buffer.mglo, offset, drawcount_offset, maxdrawcount, stride)
 
     def release(self):
         if not isinstance(self.mglo, InvalidObject):

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -2682,8 +2682,10 @@ static PyObject * MGLProgram_draw_mesh_tasks(MGLProgram * self, PyObject * args)
 static PyObject * MGLProgram_draw_mesh_tasks_indirect(MGLProgram * self, PyObject * args) {
     MGLBuffer * buffer;
     Py_ssize_t offset = 0;
+    Py_ssize_t drawcount = 1;
+    Py_ssize_t stride = 0;
 
-    if (!PyArg_ParseTuple(args, "O!|n", MGLBuffer_type, &buffer, &offset)) {
+    if (!PyArg_ParseTuple(args, "O!|nnn", MGLBuffer_type, &buffer, &offset, &drawcount, &stride)) {
         return 0;
     }
 
@@ -2691,7 +2693,26 @@ static PyObject * MGLProgram_draw_mesh_tasks_indirect(MGLProgram * self, PyObjec
 
     gl.UseProgram(self->program_obj);
     gl.BindBuffer(GL_DRAW_INDIRECT_BUFFER, buffer->buffer_obj);
-    gl.DrawMeshTasksIndirectNV((GLintptr)offset);
+    gl.MultiDrawMeshTasksIndirectNV((GLintptr)offset, (GLsizei)drawcount, (GLsizei)stride);
+    Py_RETURN_NONE;
+}
+
+static PyObject * MGLProgram_draw_mesh_tasks_indirect_count(MGLProgram * self, PyObject * args) {
+    MGLBuffer * buffer;
+    Py_ssize_t offset = 0;
+    Py_ssize_t drawcount_offset = 0;
+    Py_ssize_t maxdrawcount = 1;
+    Py_ssize_t stride = 0;
+
+    if (!PyArg_ParseTuple(args, "O!nnn|n", MGLBuffer_type, &buffer, &offset, &drawcount_offset, &maxdrawcount, &stride)) {
+        return 0;
+    }
+
+    const GLMethods & gl = self->context->gl;
+
+    gl.UseProgram(self->program_obj);
+    gl.BindBuffer(GL_DRAW_INDIRECT_BUFFER, buffer->buffer_obj);
+    gl.MultiDrawMeshTasksIndirectCountNV((GLintptr)offset, (GLintptr)drawcount_offset, (GLsizei)maxdrawcount, (GLsizei)stride);
     Py_RETURN_NONE;
 }
 
@@ -9244,6 +9265,7 @@ static PyMethodDef MGLProgram_methods[] = {
     {(char *)"run_indirect", (PyCFunction)MGLProgram_run_indirect, METH_VARARGS},
     {(char *)"draw_mesh_tasks", (PyCFunction)MGLProgram_draw_mesh_tasks, METH_VARARGS},
     {(char *)"draw_mesh_tasks_indirect", (PyCFunction)MGLProgram_draw_mesh_tasks_indirect, METH_VARARGS},
+    {(char *)"draw_mesh_tasks_indirect_count", (PyCFunction)MGLProgram_draw_mesh_tasks_indirect_count, METH_VARARGS},
     {(char *)"release", (PyCFunction)MGLProgram_release, METH_NOARGS},
     {},
 };


### PR DESCRIPTION
Rewrote `draw_mesh_tasks_indirect` to use multidraw internally (doesn't quite make sense since you can multidraw with `drawcount=1` which is default and optional), added `draw_mesh_tasks_indirect_count`. Improved example (some animation, technically uses indirect for demonstration purposes). Added stubs for mesh shader related stuff and indirect compute shader call.