### PR TITLE
Update moderngl_window examples with new callback names

### DIFF
--- a/examples/mesh_shaders.py
+++ b/examples/mesh_shaders.py
@@ -173,7 +173,7 @@ class Example(mglw.WindowConfig):
         self.camera = self.program["modelViewProjection"]
         self.u_time = self.program["time"]
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(alpha=1)
 
         proj = glm.perspective((90.0) / 180.0 * math.pi, 1.0, 0.1, 1000.0)

--- a/examples/moderngl_window_empty.py
+++ b/examples/moderngl_window_empty.py
@@ -22,18 +22,18 @@ class Example(mglw.WindowConfig):
             (math.sin(time + 3) + 1.0) / 2,
         )
 
-    def resize(self, width: int, heigh: int):
+    def on_resize(self, width: int, height: int):
         """
         Pick window resizes in case we need yo update
         internal states when this happens.
         """
-        print("Window resized to", width, heigh)
+        print("Window resized to", width, height)
 
-    def iconify(self, iconify: bool):
+    def on_iconify(self, iconified: bool):
         """Window hide/minimize and restore"""
-        print("Window was iconified:", iconify)
+        print("Window was iconified:", iconified)
 
-    def key_event(self, key, action, modifiers):
+    def on_key_event(self, key, action, modifiers):
         keys = self.wnd.keys
 
         # Key presses
@@ -89,24 +89,24 @@ class Example(mglw.WindowConfig):
             if key == keys.M:
                 self.wnd.mouse_exclusivity = not self.wnd.mouse_exclusivity
 
-    def mouse_position_event(self, x, y, dx, dy):
+    def on_mouse_position_event(self, x, y, dx, dy):
         print("Mouse position pos={} {} delta={} {}".format(x, y, dx, dy))
 
-    def mouse_drag_event(self, x, y, dx, dy):
+    def on_mouse_drag_event(self, x, y, dx, dy):
         print("Mouse drag pos={} {} delta={} {}".format(x, y, dx, dy))
 
-    def mouse_scroll_event(self, x_offset, y_offet):
-        print("mouse_scroll_event", x_offset, y_offet)
+    def on_mouse_scroll_event(self, x_offset, y_offset):
+        print("mouse_scroll_event", x_offset, y_offset)
 
-    def mouse_press_event(self, x, y, button):
+    def on_mouse_press_event(self, x, y, button):
         print("Mouse button {} pressed at {}, {}".format(button, x, y))
         print("Mouse states:", self.wnd.mouse_states)
 
-    def mouse_release_event(self, x: int, y: int, button: int):
+    def on_mouse_release_event(self, x: int, y: int, button: int):
         print("Mouse button {} released at {}, {}".format(button, x, y))
         print("Mouse states:", self.wnd.mouse_states)
 
-    def unicode_char_entered(self, char):
+    def on_unicode_char_entered(self, char):
         print("unicode_char_entered:", char)
 
 

--- a/examples/moderngl_window_empty.py
+++ b/examples/moderngl_window_empty.py
@@ -15,7 +15,7 @@ class Example(mglw.WindowConfig):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(
             (math.sin(time) + 1.0) / 2,
             (math.sin(time + 2) + 1.0) / 2,

--- a/examples/moderngl_window_fractal.py
+++ b/examples/moderngl_window_fractal.py
@@ -72,7 +72,7 @@ class Example(mglw.WindowConfig):
         self.vao = self.ctx.vertex_array(self.program, [])
         self.vao.vertices = 3
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear()
         self.program['seed'] = (-0.8, 0.156)
         self.program['iter'] = 100

--- a/examples/moderngl_window_resources.py
+++ b/examples/moderngl_window_resources.py
@@ -77,7 +77,7 @@ class Example(mglw.WindowConfig):
         look = glm.lookAt((-85.0, -180.0, 140.0), (0.0, 0.0, 65.0), (0.0, 0.0, 1.0))
         return proj * look
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)
 

--- a/examples/old/attribute_locations.py
+++ b/examples/old/attribute_locations.py
@@ -51,7 +51,7 @@ class HelloWorld(Example):
             self.vbo.bind(3, 7),
         ])
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render()
 

--- a/examples/old/basic_alpha_blending.py
+++ b/examples/old/basic_alpha_blending.py
@@ -65,7 +65,7 @@ class AlphaBlending(Example):
             self.vbo.bind('vert', 'vert_color'),
         ])
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.BLEND)
         self.rotation.value = time

--- a/examples/old/basic_colors_and_texture.py
+++ b/examples/old/basic_colors_and_texture.py
@@ -87,7 +87,7 @@ class ColorsAndTexture(Example):
         # texture on billboard
         self.texture = self.load_texture_2d('infographic-1.jpg')
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST | moderngl.CULL_FACE)
 

--- a/examples/old/basic_empty_window.py
+++ b/examples/old/basic_empty_window.py
@@ -14,7 +14,7 @@ class EmptyWindow(Example):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(
             (math.sin(time) + 1.0) / 2,
             (math.sin(time + 2) + 1.0) / 2,

--- a/examples/old/basic_index_buffer.py
+++ b/examples/old/basic_index_buffer.py
@@ -59,7 +59,7 @@ class IndexBuffer(Example):
 
         self.vao = self.ctx.vertex_array(self.prog, vao_content, self.ibo)
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render()
 

--- a/examples/old/basic_perspective_projection.py
+++ b/examples/old/basic_perspective_projection.py
@@ -92,7 +92,7 @@ class PerspectiveProjection(Example):
         self.vbo = self.ctx.buffer(grid)
         self.vao = self.ctx.vertex_array(self.prog, [self.vbo.bind('vert')])
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render(moderngl.LINES, 65 * 4)
 

--- a/examples/old/basic_simple_color_triangle.py
+++ b/examples/old/basic_simple_color_triangle.py
@@ -63,7 +63,7 @@ class SimpleColorTriangle(Example):
             ],
         )
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render()
 

--- a/examples/old/basic_uniforms_and_attributes.py
+++ b/examples/old/basic_uniforms_and_attributes.py
@@ -54,7 +54,7 @@ class UniformsAndAttributes(Example):
         self.vbo = self.ctx.buffer(vertices)
         self.vao = self.ctx.vertex_array(self.prog, [self.vbo.bind('vert')])
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         sin_scale = np.sin(np.deg2rad(time * 60))
 
         self.ctx.clear(1.0, 1.0, 1.0)

--- a/examples/old/bind_frag_data_location.py
+++ b/examples/old/bind_frag_data_location.py
@@ -67,7 +67,7 @@ class CrateExample(Example):
         self.vao = self.scene.root_nodes[0].mesh.vao.instance(self.prog)
         self.texture = self.load_texture_2d('crate.png')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/bindless_textures.py
+++ b/examples/old/bindless_textures.py
@@ -62,7 +62,7 @@ class CrateExample(Example):
 
         self.prog['Texture'].handle = self.texture.get_handle()
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/compute_shader_render_texture.py
+++ b/examples/old/compute_shader_render_texture.py
@@ -74,7 +74,7 @@ class RenderTextureCompute(Example):
         self.texture.filter = mgl.NEAREST, mgl.NEAREST
         self.quad_fs = geometry.quad_fs()
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(0.3, 0.3, 0.3)
 
         w, h = self.texture.size

--- a/examples/old/compute_shader_ssbo.py
+++ b/examples/old/compute_shader_ssbo.py
@@ -231,7 +231,7 @@ class ComputeShaderSSBO(Example):
             yield 1.0
 
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         # Calculate the next position of the balls with compute shader
         self.compute_buffer_a.bind_to_storage_buffer(0)
         self.compute_buffer_b.bind_to_storage_buffer(1)

--- a/examples/old/conways_game_of_life.py
+++ b/examples/old/conways_game_of_life.py
@@ -130,7 +130,7 @@ class Conway(Example):
         self.tao = self.ctx.vertex_array(self.transform_prog, [])
         self.pbo = self.ctx.buffer(reserve=pixels.nbytes)  # buffer to store the result
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
 
         # Bind texture to channel 0

--- a/examples/old/crate.py
+++ b/examples/old/crate.py
@@ -58,7 +58,7 @@ class CrateExample(Example):
         self.vao = self.scene.root_nodes[0].mesh.vao.instance(self.prog)
         self.texture = self.load_texture_2d('crate.png')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/crate_uniform_buffer.py
+++ b/examples/old/crate_uniform_buffer.py
@@ -69,7 +69,7 @@ class CrateExample(Example):
         self.vao = self.scene.root_nodes[0].mesh.vao.instance(self.prog)
         self.texture = self.load_texture_2d('crate.png')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/custom_window/qtmoderngl.py
+++ b/examples/old/custom_window/qtmoderngl.py
@@ -27,7 +27,7 @@ class QModernGLWidget(QtOpenGL.QGLWidget):
     def init(self):
         pass
 
-    def render(self):
+    def on_render(self):
         pass
 
 
@@ -55,5 +55,5 @@ class QModernGLWidgetOld(QtWidgets.QOpenGLWidget):
     def init(self):
         pass
 
-    def render(self):
+    def on_render(self):
         pass

--- a/examples/old/empty_framebuffer.py
+++ b/examples/old/empty_framebuffer.py
@@ -53,7 +53,7 @@ class HelloWorld(Example):
 
         self.fbo = self.ctx.framebuffer([self.texture])
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.fbo.clear(1.0, 1.0, 1.0, 1.0)
         self.vao.render()
         self.ctx.memory_barrier()

--- a/examples/old/empty_vertex_array.py
+++ b/examples/old/empty_vertex_array.py
@@ -51,7 +51,7 @@ class HelloWorld(Example):
         self.vao = self.ctx.vertex_array(self.prog, [])
         self.vao.vertices = 3
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render()
 

--- a/examples/old/empty_vertexbuffer.py
+++ b/examples/old/empty_vertexbuffer.py
@@ -51,7 +51,7 @@ class HelloWorld(Example):
         )
         self.vao = self.ctx.vertex_array(self.prog, [])
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render(mode=moderngl.POINTS, vertices=100, instances=2)
 

--- a/examples/old/fragment_output.py
+++ b/examples/old/fragment_output.py
@@ -67,7 +67,7 @@ class CrateExample(Example):
         self.vao = self.scene.root_nodes[0].mesh.vao.instance(self.prog)
         self.texture = self.load_texture_2d('crate.png')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/geometry_shader_sprites.py
+++ b/examples/old/geometry_shader_sprites.py
@@ -134,7 +134,7 @@ class GeoSprites(Example):
             ]
         )
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear()
         self.ctx.enable(moderngl.BLEND)
 

--- a/examples/old/growing_buffers.py
+++ b/examples/old/growing_buffers.py
@@ -105,7 +105,7 @@ class GrowingBuffers(Example):
         self.points = Points(self.ctx, 12 * 10)
         self.points.add(10)
 
-    def render(self, time, frametime):
+    def on_render(self, time, frametime):
         self.points.render(time)
 
         # Add more points every 60 frames

--- a/examples/old/heightmap_on_the_fly.py
+++ b/examples/old/heightmap_on_the_fly.py
@@ -153,7 +153,7 @@ class HeightmapOnTheFly(Example):
         self.prog['dim'] = self.dim - 1
         self.prog['terrain_size'] = 1.0
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear()
         self.ctx.enable(moderngl.DEPTH_TEST | moderngl.CULL_FACE)
         angle = time * 0.2

--- a/examples/old/hello_world.py
+++ b/examples/old/hello_world.py
@@ -44,7 +44,7 @@ class HelloWorld(Example):
         self.vbo = self.ctx.buffer(vertices)
         self.vao = self.ctx.simple_vertex_array(self.prog, self.vbo, 'in_vert')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render()
 

--- a/examples/old/image_shader_example.py
+++ b/examples/old/image_shader_example.py
@@ -18,7 +18,7 @@ class ImageProcessing(moderngl_window.WindowConfig):
         self.image_processing = ImageTransformer(self.ctx, self.window_size)
         self.texture = self.load_texture_2d("data/ball.png")
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.image_processing.render(self.texture, target=self.ctx.screen)
 
         # Headless
@@ -92,7 +92,7 @@ class ImageTransformer:
             ]
         )
 
-    def render(self, texture, target=None):
+    def on_render(self, texture, target=None):
         if target:
             target.use()
         else:

--- a/examples/old/instance_only_vertex_attribute.py
+++ b/examples/old/instance_only_vertex_attribute.py
@@ -60,7 +60,7 @@ class HelloWorld(Example):
         ])
         self.vao.vertices = 3
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render(instances=100)
 

--- a/examples/old/instanced_rendering.py
+++ b/examples/old/instanced_rendering.py
@@ -63,7 +63,7 @@ class InstancedRendering(Example):
             [(self.vbo, '2f 4f', 'in_vert', 'in_color')],
         )
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.BLEND)
         self.scale.value = (0.5, self.aspect_ratio * 0.5)

--- a/examples/old/instanced_rendering_crates.py
+++ b/examples/old/instanced_rendering_crates.py
@@ -81,7 +81,7 @@ class InstancedCrates(Example):
         self.crate_x += np.random.uniform(-0.2, 0.2, 32 * 32)
         self.crate_y += np.random.uniform(-0.2, 0.2, 32 * 32)
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time * 0.2
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/integration_pycairo.py
+++ b/examples/old/integration_pycairo.py
@@ -64,7 +64,7 @@ class CairoExample(Example):
             ],
         )
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.texture.use(location=0)
         self.screen_rectangle.render(mode=moderngl.TRIANGLE_STRIP)
 

--- a/examples/old/julia_fractal.py
+++ b/examples/old/julia_fractal.py
@@ -65,7 +65,7 @@ class Fractal(Example):
         self.vbo = self.ctx.buffer(vertices.astype('f4'))
         self.vao = self.ctx.simple_vertex_array(self.prog, self.vbo, 'in_vert')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
 
         self.center.value = (0.49, 0.32)

--- a/examples/old/julia_set.py
+++ b/examples/old/julia_set.py
@@ -66,7 +66,7 @@ class Fractal(Example):
         self.vbo = self.ctx.buffer(vertices.astype('f4'))
         self.vao = self.ctx.simple_vertex_array(self.prog, self.vbo, 'in_vert')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
 
         self.seed.value = (-0.8, 0.156)

--- a/examples/old/loading_obj_files.py
+++ b/examples/old/loading_obj_files.py
@@ -71,7 +71,7 @@ class LoadingOBJ(Example):
         # Create a vao from the first root node (attribs are auto mapped)
         self.vao = self.obj.root_nodes[0].mesh.vao.instance(self.prog)
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)
 

--- a/examples/old/mandelbrot_set.py
+++ b/examples/old/mandelbrot_set.py
@@ -73,7 +73,7 @@ class Fractal(Example):
         self.vbo = self.ctx.buffer(vertices.astype('f4'))
         self.vao = self.ctx.simple_vertex_array(self.prog, self.vbo, 'in_vert')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
 
         self.center.value = (0.5, 0.0)

--- a/examples/old/multi_texture_terrain.py
+++ b/examples/old/multi_texture_terrain.py
@@ -98,7 +98,7 @@ class MultiTextireTerrain(Example):
         self.prog['Cracks'].value = 3
         self.prog['Darken'].value = 4
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time * 0.2
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/multiple_instance_rendering.py
+++ b/examples/old/multiple_instance_rendering.py
@@ -109,7 +109,7 @@ class InstancedRendering(Example):
 
         self.vao = self.ctx.vertex_array(self.prog, vao_content, self.index_buffer)
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.vao.render(instances=8)
 

--- a/examples/old/particle_system.py
+++ b/examples/old/particle_system.py
@@ -74,7 +74,7 @@ class Particles(Example):
 
         self.idx = 0
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.point_size = 2.0
 

--- a/examples/old/particle_system_advanced.py
+++ b/examples/old/particle_system_advanced.py
@@ -203,7 +203,7 @@ class Particles(Example):
         self.vao1.transform(self.vbo2, moderngl.POINTS, self.nb_particles)
         self.ctx.copy_buffer(self.vbo1, self.vbo2)
 
-    def render(self, time, _frame_time) -> None:
+    def on_render(self, time, _frame_time) -> None:
         # Physic pass: update particles system
         self.update_particles(time)
         # Rendering pass: render particles system

--- a/examples/old/particle_system_emit.py
+++ b/examples/old/particle_system_emit.py
@@ -234,7 +234,7 @@ class Particles(Example):
         # Query object to inspect render calls
         self.query = self.ctx.query(primitives=True)
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.transform['ft'].value = max(frame_time, 0.02)
 
         if not self.mouse_control:

--- a/examples/old/points_variable_size.py
+++ b/examples/old/points_variable_size.py
@@ -71,7 +71,7 @@ class Particles(Example):
         )
         self.resize(*self.wnd.buffer_size)
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.enable_only(moderngl.PROGRAM_POINT_SIZE | moderngl.BLEND)
         self.ctx.blend_func = moderngl.ADDITIVE_BLENDING
 

--- a/examples/old/polygon_offset.py
+++ b/examples/old/polygon_offset.py
@@ -74,7 +74,7 @@ class PolygonOffset(moderngl_window.WindowConfig):
         self.projection = Matrix44.perspective_projection(60, self.wnd.aspect_ratio, 1, 100, dtype="f4")
         self.poly_offset_enabled = True
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear()
         self.ctx.enable(self.ctx.DEPTH_TEST | self.ctx.CULL_FACE)
 

--- a/examples/old/raymarching.py
+++ b/examples/old/raymarching.py
@@ -45,7 +45,7 @@ class Raymarching(Example):
         self.vao = self.ctx.vertex_array(program, content, idx_buffer)
         self.u_time = program.get("T", 0.0)
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.u_time.value = time
         self.vao.render()
 

--- a/examples/old/render_to_texture.py
+++ b/examples/old/render_to_texture.py
@@ -14,7 +14,7 @@ class RenderToTexture(ColorsAndTexture):
         depth_attachment = self.ctx.depth_renderbuffer(self.wnd.size)
         self.fbo = self.ctx.framebuffer(self.texture2, depth_attachment)
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         for mode in ['render_to_texture', 'render_to_window']:
             if mode == 'render_to_texture':
                 self.texture = self.texture1

--- a/examples/old/rich_lines.py
+++ b/examples/old/rich_lines.py
@@ -93,7 +93,7 @@ class RichLines(Example):
             Matrix44.orthogonal_projection(0, 1600, 800, 0, 0.5, -0.5, dtype="f4")
         )
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1, 1, 1, 1)
         self.ctx.enable(moderngl.BLEND)
         self.vao.render(moderngl.LINE_STRIP_ADJACENCY)

--- a/examples/old/scissor.py
+++ b/examples/old/scissor.py
@@ -51,7 +51,7 @@ class Scissor(Example):
         vbo = self.ctx.buffer(np.array(quad, dtype='f4'))
         self.vao = self.ctx.simple_vertex_array(self.prog, vbo, 'in_vert')
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         """Swap between rendering geometry and using clear"""
         fb_width_half = self.wnd.buffer_width // 2
         fb_height_half = self.wnd.buffer_height // 2

--- a/examples/old/shadowmapping.py
+++ b/examples/old/shadowmapping.py
@@ -164,7 +164,7 @@ class ShadowMappingSample(Example):
 
         self.ctx.enable(moderngl.CULL_FACE)
 
-    def render(self, time: float, _frame_time: float):
+    def on_render(self, time: float, _frame_time: float):
         # pass 0: clear buffers
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/simple_camera.py
+++ b/examples/old/simple_camera.py
@@ -206,7 +206,7 @@ class PerspectiveProjection(Example):
         else:
             self.states[key] = False
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.move_camera()
 
         self.ctx.clear(1.0, 1.0, 1.0)

--- a/examples/old/simple_grid.py
+++ b/examples/old/simple_grid.py
@@ -47,7 +47,7 @@ class SimpleGrid(Example):
         self.vbo = self.ctx.buffer(grid(15, 10).astype('f4'))
         self.vao = self.ctx.simple_vertex_array(self.prog, self.vbo, 'in_vert')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)
 

--- a/examples/old/subprocess_texture.py
+++ b/examples/old/subprocess_texture.py
@@ -63,7 +63,7 @@ class SubprocessTest(moderngl_window.WindowConfig):
         except Empty:
             pass
 
-    def render(self, time: float, frame_time: float):
+    def on_render(self, time: float, frame_time: float):
         self.ctx.clear()
         self.texture.use()
         self.program["model"].write(matrix44.create_from_axis_rotation([0.0, 0.0, 1.0], time, dtype="f4"))

--- a/examples/old/tesselation.py
+++ b/examples/old/tesselation.py
@@ -86,7 +86,7 @@ class Tessellation(Example):
         vbo = self.ctx.buffer(vertices.astype('f4'))
         self.vao = self.ctx.simple_vertex_array(self.prog, vbo, 'in_pos')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.ctx.clear(0.2, 0.4, 0.7)
         self.vao.render(mode=moderngl.PATCHES)
 

--- a/examples/old/toy_cars_with_vector_shadow.py
+++ b/examples/old/toy_cars_with_vector_shadow.py
@@ -91,7 +91,7 @@ class ToyCars(Example):
         vao_wrapper.buffer(self.vbo, '3f 3f 9f/i', ['in_color', 'in_origin', 'in_basis'])
         self.vao = vao_wrapper.instance(self.prog)
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time
         self.ctx.clear(1.0, 1.0, 1.0)
         self.ctx.enable(moderngl.DEPTH_TEST)

--- a/examples/old/transform_feedback_changing_primitive.py
+++ b/examples/old/transform_feedback_changing_primitive.py
@@ -85,7 +85,7 @@ class GenerateData(Example):
             [(self.buffer, '3f', 'in_vert')]
         )
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.wnd.clear()
         self.vao.render(mode=moderngl.TRIANGLES)
 

--- a/examples/old/transform_feedback_gen_buffer.py
+++ b/examples/old/transform_feedback_gen_buffer.py
@@ -39,7 +39,7 @@ class GenerateData(Example):
         for i in range(0, N * 6, 6):
             print(data[i:i + 3], data[i + 3:i + 6])
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         exit(0)
 
 

--- a/examples/old/transform_feedback_multiple_buffers.py
+++ b/examples/old/transform_feedback_multiple_buffers.py
@@ -46,7 +46,7 @@ class GenerateData(Example):
         print(output_array_0)
         print(output_array_1)
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         exit(0)
 
 

--- a/examples/old/using_pymunk.py
+++ b/examples/old/using_pymunk.py
@@ -128,7 +128,7 @@ class PymunkExample(Example):
         if action == self.wnd.keys.ACTION_PRESS:
             self.shoot()
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         width, height = self.wnd.size
 
         self.ctx.clear(1.0, 1.0, 1.0)

--- a/examples/old/wireframe_terrain.py
+++ b/examples/old/wireframe_terrain.py
@@ -65,7 +65,7 @@ class WireframeTerrain(Example):
         self.vao = self.ctx.vertex_array(self.prog, vao_content, self.ibo)
         self.texture = self.load_texture_2d('noise.jpg')
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time * 0.2
 
         self.ctx.clear(1.0, 1.0, 1.0)

--- a/examples/water/water_main.py
+++ b/examples/water/water_main.py
@@ -183,7 +183,7 @@ class WaterMain(mglw.WindowConfig):
         self.water.update_normals()
         self.renderer.update_caustics(self.matrices, self.water)
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         self.matrices.view = glm.lookAt(
             self.eye, (0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
 

--- a/examples/water/water_main.py
+++ b/examples/water/water_main.py
@@ -117,12 +117,12 @@ class WaterMain(mglw.WindowConfig):
         self.center = center
         self.prev_hit = next_hit
 
-    def mouse_release_event(self, x: int, y: int, button: int):
+    def on_mouse_release_event(self, x: int, y: int, button: int):
         if button == 1:
             self.mode = EventMode.NoEvent
             self.tracer = None
 
-    def mouse_press_event(self, x: int, y: int, button: int):
+    def on_mouse_press_event(self, x: int, y: int, button: int):
         self.tracer = RayTracer(self.ctx.viewport, self.matrices)
         ray = self.tracer.get_ray_for_pixel(x, y)
         sphere_hit_test: HitTest = RayTracer.hit_test_sphere(
@@ -143,7 +143,7 @@ class WaterMain(mglw.WindowConfig):
             self.tracer_mesh = WaterMain.dbg_tracer_mesh(
                 self.ctx, self.tracer, point_on_panel)
 
-    def mouse_drag_event(self, x: int, y: int, dx: int, dy: int):
+    def on_mouse_drag_event(self, x: int, y: int, dx: int, dy: int):
         match self.mode:
             case EventMode.AddDrop:
                 self.add_drop(x, y)
@@ -153,7 +153,7 @@ class WaterMain(mglw.WindowConfig):
             case EventMode.MoveSpahere:
                 self.move_sphere(x, y)
 
-    def key_event(self, key, action, modifiers):
+    def on_key_event(self, key, action, modifiers):
         if key == ord('G') and action == 1:
             self.use_gravity = not self.use_gravity
 

--- a/examples/water/water_sim.py
+++ b/examples/water/water_sim.py
@@ -45,7 +45,7 @@ class WaterSimulation(mglw.WindowConfig):
     def heavy(self, value):
         self._heavy = min(10, max(0, value))
 
-    def key_event(self, key, action, modifiers):
+    def on_key_event(self, key, action, modifiers):
         if action == 1:
             if key == 265: # up arrow
                 self.heavy += 1

--- a/examples/water/water_sim.py
+++ b/examples/water/water_sim.py
@@ -52,7 +52,7 @@ class WaterSimulation(mglw.WindowConfig):
             elif key == 264: # down arrow
                 self.heavy -= 1
 
-    def render(self, time, frame_time):
+    def on_render(self, time, frame_time):
         angle = time * 0.2
         self.matrix.projection = glm.perspective(
             45.0, self.aspect_ratio, 0.1, 1000.0)


### PR DESCRIPTION
https://github.com/moderngl/moderngl-window/pull/203 changed the name of the `render` callback to `on_render` (among others). This change hasn't been reflected in the examples here and so they do not run with the latest moderngl_window package from pypi.

The water example is broken on my machine due to deprecated glsl code, which prevents the shaders from compiling, however the other examples do all work.

I've updated parts of the old examples as well, but many of them are broken with being moved into the `examples/old/` directory and I really can't be bothered to test all of them given that they're old anyway.