### PR TITLE
Gil release during major blocking operations

### DIFF
--- a/docs/reference/buffer.rst
+++ b/docs/reference/buffer.rst
@@ -26,14 +26,15 @@ Methods
     :param bytes data: The data.
     :param int offset: The offset in bytes.
 
-.. py:method:: Buffer.read(size: int = -1, *, offset: int = 0) -> bytes:
+.. py:method:: Buffer.read(size: int = -1, *, offset: int = 0, gil=False) -> bytes:
 
     Read the content.
 
     :param int size: The size in bytes. Value ``-1`` means all.
     :param int offset: The offset in bytes.
+    :param bool gil: Whether to hold the GIL while waiting for the data.
 
-.. py:method:: Buffer.read_into(buffer: Any, size: int = -1, *, offset: int = 0, write_offset: int = 0) -> None:
+.. py:method:: Buffer.read_into(buffer: Any, size: int = -1, *, offset: int = 0, write_offset: int = 0, gil=False) -> None:
 
     Read the content into a buffer.
 
@@ -41,6 +42,7 @@ Methods
     :param int size: The size in bytes. Value ``-1`` means all.
     :param int offset: The read offset in bytes.
     :param int write_offset: The write offset in bytes.
+    :param bool gil: Whether to hold the GIL while waiting for the data.
 
 .. py:method:: Buffer.clear(size: int = -1, *, offset: int = 0, chunk: Any = None) -> None:
 

--- a/docs/reference/framebuffer.rst
+++ b/docs/reference/framebuffer.rst
@@ -38,7 +38,7 @@ Methods
     :param tuple viewport: The viewport.
     :param tuple color: Optional tuple replacing the red, green, blue and alpha arguments
 
-.. py:method:: Framebuffer.read(viewport=..., components: int = 3, attachment: int = 0, alignment: int = 1, dtype: str = 'f1', clamp: bool = False) -> bytes
+.. py:method:: Framebuffer.read(viewport=..., components: int = 3, attachment: int = 0, alignment: int = 1, dtype: str = 'f1', clamp: bool = False, gil: bool = False) -> bytes
 
     Read the content of the framebuffer.
 
@@ -48,6 +48,7 @@ Methods
     :param int alignment: The byte alignment of the pixels.
     :param str dtype: Data type.
     :param bool clamp: Clamps floating point values to ``[0.0, 1.0]``
+    :param bool gil: Whether to hold the GIL while waiting for the data.
 
     .. code:: python
 
@@ -60,7 +61,7 @@ Methods
         # Read the lower left 10 x 10 pixels from the first color attachment
         data = fbo.read(viewport=(0, 0, 10, 10))
 
-.. py:method:: Framebuffer.read_into(buffer, viewport, components: int = 3, attachment: int = 0, alignment: int = 1, dtype: str = 'f1', write_offset: int = 0) -> None
+.. py:method:: Framebuffer.read_into(buffer, viewport, components: int = 3, attachment: int = 0, alignment: int = 1, dtype: str = 'f1', write_offset: int = 0, gil: bool = False) -> None
 
     Read the content of the framebuffer into a buffer.
 
@@ -71,6 +72,7 @@ Methods
     :param int alignment: The byte alignment of the pixels.
     :param str dtype: Data type.
     :param int write_offset: The write offset.
+    :param bool gil: Whether to hold the GIL while waiting for the data.
 
 .. py:method:: Framebuffer.use()
 

--- a/docs/reference/texture.rst
+++ b/docs/reference/texture.rst
@@ -18,13 +18,14 @@ Texture
 Methods
 -------
 
-.. py:method:: Texture.read(alignment: int = 1) -> bytes
+.. py:method:: Texture.read(alignment: int = 1, gil=False) -> bytes
 
     Read the pixel data as bytes into system memory.
 
     :param int alignment: The byte alignment of the pixels.
+    :param bool gil: Whether to hold the GIL while waiting for the data.
 
-.. py:method:: Texture.read_into(buffer: Any, alignment: int = 1, write_offset: int = 0)
+.. py:method:: Texture.read_into(buffer: Any, alignment: int = 1, write_offset: int = 0, gil=False)
 
     Read the content of the texture into a bytearray or :py:class:`~moderngl.Buffer`.
 
@@ -44,6 +45,7 @@ Methods
     :param bytearray buffer: The buffer that will receive the pixels.
     :param int alignment: The byte alignment of the pixels.
     :param int write_offset: The write offset.
+    :param bool gil: Whether to hold the GIL while waiting for the data.
 
 .. py:method:: Texture.write(data: Any, viewport: tuple, alignment: int = 1)
 

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -90,17 +90,17 @@ class Buffer:
     def write_chunks(self, data, start, step, count):
         self.mglo.write_chunks(data, start, step, count)
 
-    def read(self, size=-1, offset=0):
-        return self.mglo.read(size, offset)
+    def read(self, size=-1, offset=0, gil=False):
+        return self.mglo.read(size, offset, gil)
 
-    def read_into(self, buffer, size=-1, offset=0, write_offset=0):
-        return self.mglo.read_into(buffer, size, offset, write_offset)
+    def read_into(self, buffer, size=-1, offset=0, write_offset=0, gil=False):
+        return self.mglo.read_into(buffer, size, offset, write_offset, gil)
 
-    def read_chunks(self, chunk_size, start, step, count):
-        return self.mglo.read_chunks(chunk_size, start, step, count)
+    def read_chunks(self, chunk_size, start, step, count, gil=False):
+        return self.mglo.read_chunks(chunk_size, start, step, count, gil)
 
-    def read_chunks_into(self, buffer, chunk_size, start, step, count, write_offset=0):
-        return self.mglo.read(buffer, chunk_size, start, step, count, write_offset)
+    def read_chunks_into(self, buffer, chunk_size, start, step, count, write_offset=0, gil=False):
+        return self.mglo.read(buffer, chunk_size, start, step, count, write_offset, gil)
 
     def clear(self, size=-1, offset=0, chunk=None):
         self.mglo.clear(size, offset, chunk)
@@ -359,22 +359,22 @@ class Framebuffer:
         self.ctx.fbo = self
         self.mglo.use()
 
-    def read(self, viewport=None, components=3, attachment=0, alignment=1, dtype="f1", clamp=False):
+    def read(self, viewport=None, components=3, attachment=0, alignment=1, dtype="f1", clamp=False, gil=False):
         if viewport is None:
             viewport = (0, 0, self.width, self.height)
         if len(viewport) == 2:
             viewport = (0, 0, *viewport)
         res, mem = mgl.writable_bytes(mgl.expected_size(viewport[2], viewport[3], 1, components, alignment, dtype))
-        self.mglo.read_into(mem, viewport, components, attachment, alignment, clamp, dtype, 0)
+        self.mglo.read_into(mem, viewport, components, attachment, alignment, clamp, dtype, 0, gil)
         return res
 
-    def read_into(
-        self, buffer, viewport=None, components=3, attachment=0, alignment=1, dtype="f1", clamp=False, write_offset=0
-    ):
+    def read_into(self, buffer, 
+            viewport=None, components=3, attachment=0, alignment=1, dtype="f1", 
+            clamp=False, write_offset=0, gil=False):
         if type(buffer) is Buffer:
             buffer = buffer.mglo
 
-        return self.mglo.read_into(buffer, viewport, components, attachment, alignment, clamp, dtype, write_offset)
+        return self.mglo.read_into(buffer, viewport, components, attachment, alignment, clamp, dtype, write_offset, gil)
 
     def release(self):
         if not isinstance(self.mglo, InvalidObject):
@@ -830,14 +830,14 @@ class Texture:
         else:
             self._label = value
 
-    def read(self, level=0, alignment=1):
-        return self.mglo.read(level, alignment)
+    def read(self, level=0, alignment=1, gil=False):
+        return self.mglo.read(level, alignment, gil)
 
-    def read_into(self, buffer, level=0, alignment=1, write_offset=0):
+    def read_into(self, buffer, level=0, alignment=1, write_offset=0, gil=False):
         if type(buffer) is Buffer:
             buffer = buffer.mglo
 
-        return self.mglo.read_into(buffer, level, alignment, write_offset)
+        return self.mglo.read_into(buffer, level, alignment, write_offset, gil)
 
     def write(self, data, viewport=None, level=0, alignment=1):
         if type(data) is Buffer:
@@ -970,14 +970,14 @@ class Texture3D:
         else:
             self._label = value
 
-    def read(self, alignment=1):
-        return self.mglo.read(alignment)
+    def read(self, alignment=1, gil=False):
+        return self.mglo.read(alignment, gil)
 
-    def read_into(self, buffer, alignment=1, write_offset=0):
+    def read_into(self, buffer, alignment=1, write_offset=0, gil=False):
         if type(buffer) is Buffer:
             buffer = buffer.mglo
 
-        return self.mglo.read_into(buffer, alignment, write_offset)
+        return self.mglo.read_into(buffer, alignment, write_offset, gil)
 
     def write(self, data, viewport=None, alignment=1):
         if type(data) is Buffer:
@@ -1094,14 +1094,14 @@ class TextureCube:
         else:
             self._label = value
 
-    def read(self, face, alignment=1):
-        return self.mglo.read(face, alignment)
+    def read(self, face, alignment=1, gil=False):
+        return self.mglo.read(face, alignment, gil)
 
-    def read_into(self, buffer, face, alignment=1, write_offset=0):
+    def read_into(self, buffer, face, alignment=1, write_offset=0, gil=False):
         if type(buffer) is Buffer:
             buffer = buffer.mglo
 
-        return self.mglo.read_into(buffer, face, alignment, write_offset)
+        return self.mglo.read_into(buffer, face, alignment, write_offset, gil)
 
     def write(self, face, data, viewport=None, alignment=1):
         if type(data) is Buffer:
@@ -1235,14 +1235,14 @@ class TextureArray:
         else:
             self._label = value
 
-    def read(self, alignment=1):
-        return self.mglo.read(alignment)
+    def read(self, alignment=1, gil=False):
+        return self.mglo.read(alignment, gil)
 
-    def read_into(self, buffer, alignment=1, write_offset=0):
+    def read_into(self, buffer, alignment=1, write_offset=0, gil=False):
         if type(buffer) is Buffer:
             buffer = buffer.mglo
 
-        return self.mglo.read_into(buffer, alignment, write_offset)
+        return self.mglo.read_into(buffer, alignment, write_offset, gil)
 
     def write(self, data, viewport=None, alignment=1):
         if type(data) is Buffer:


### PR DESCRIPTION
Most openGL calls are non-blocking because they simply queue commands on the GPU, only some calls are blocking the calling thread. These are call synchonizing with the GPU (explicitely like `finish`  or implicitely while retreiving data or mapping buffers from the GPU).

The current modernGL implementation holds the GIL during all operations, causing the python interpreter to freeze all its threads when one of them performing such a synchronization. 
This is not a concern in single-thread programs, but may be a major performance issue in multithread programs (with other threads doing IOs or computations for instance)

This PR proposes to release the [GIL](https://docs.python.org/3/c-api/init.html#thread-state-and-the-global-interpreter-lock) during these blocking operations

impacted methods:
- `Context.finish`
- `Buffer.read*`
- `Texture*.read*`

buffer writing methods also perform synchonization since moderngl implement them using [`glMapBufferRange`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml), but discussing with @szabolcsdombi, lets consider they should not block for too long when the user do not write to buffers after rendering them