### PR TITLE
fix example perspective projection field of view

### DIFF
--- a/examples/03_camera.py
+++ b/examples/03_camera.py
@@ -49,7 +49,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/04_vertex_buffer.py
+++ b/examples/04_vertex_buffer.py
@@ -52,7 +52,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/05_uniforms.py
+++ b/examples/05_uniforms.py
@@ -56,7 +56,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/06_multiple_objects.py
+++ b/examples/06_multiple_objects.py
@@ -77,7 +77,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/07_different_geometries.py
+++ b/examples/07_different_geometries.py
@@ -112,7 +112,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/08_texture.py
+++ b/examples/08_texture.py
@@ -140,7 +140,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/09_models_and_images.py
+++ b/examples/09_models_and_images.py
@@ -117,7 +117,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/10_lighting.py
+++ b/examples/10_lighting.py
@@ -120,7 +120,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/11_multiple_programs.py
+++ b/examples/11_multiple_programs.py
@@ -176,7 +176,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now), math.sin(now), 0.5)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/12_uniform_buffer.py
+++ b/examples/12_uniform_buffer.py
@@ -22,7 +22,7 @@ class UniformBuffer:
         self.ubo = self.ctx.buffer(self.data)
 
     def set_camera(self, eye, target):
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, target, (0.0, 0.0, 1.0))
         camera = proj * look
         self.data[0:64] = camera.to_bytes()

--- a/examples/13_shader_includes.py
+++ b/examples/13_shader_includes.py
@@ -90,7 +90,7 @@ class UniformBuffer:
         self.ubo = self.ctx.buffer(self.data)
 
     def set_camera(self, eye, target):
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, target, (0.0, 0.0, 1.0))
         camera = proj * look
         self.data[0:64] = camera.to_bytes()

--- a/examples/14_postprocessing.py
+++ b/examples/14_postprocessing.py
@@ -142,7 +142,7 @@ class UniformBuffer:
         self.ubo = self.ctx.buffer(self.data)
 
     def set_camera(self, eye, target):
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, target, (0.0, 0.0, 1.0))
         camera = proj * look
         self.data[0:64] = camera.to_bytes()

--- a/examples/15_pillow_overlay.py
+++ b/examples/15_pillow_overlay.py
@@ -205,7 +205,7 @@ class UniformBuffer:
         self.ubo = self.ctx.buffer(self.data)
 
     def set_camera(self, eye, target):
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, target, (0.0, 0.0, 1.0))
         camera = proj * look
         self.data[0:64] = camera.to_bytes()

--- a/examples/external_buffer.py
+++ b/examples/external_buffer.py
@@ -83,7 +83,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now) * 3.0, math.sin(now) * 3.0, 1.75)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.5), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/external_texture.py
+++ b/examples/external_texture.py
@@ -85,7 +85,7 @@ class Scene:
     def camera_matrix(self):
         now = pygame.time.get_ticks() / 1000.0
         eye = (math.cos(now) * 3.0, math.sin(now) * 3.0, 1.75)
-        proj = glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
         look = glm.lookAt(eye, (0.0, 0.0, 0.5), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/moderngl_window_resources.py
+++ b/examples/moderngl_window_resources.py
@@ -1,4 +1,5 @@
 import os
+import math
 
 import glm
 import moderngl
@@ -73,7 +74,7 @@ class Example(mglw.WindowConfig):
         self.vao = self.obj.root_nodes[0].mesh.vao.instance(self.program)
 
     def camera_matrix(self):
-        proj = glm.perspective(45.0, self.aspect_ratio, 0.1, 1000.0)
+        proj = glm.perspective(math.radians(60.0), self.aspect_ratio, 0.1, 1000.0)
         look = glm.lookAt((-85.0, -180.0, 140.0), (0.0, 0.0, 65.0), (0.0, 0.0, 1.0))
         return proj * look
 

--- a/examples/water/light_gl.py
+++ b/examples/water/light_gl.py
@@ -3,6 +3,7 @@
 # Copyright 2011 Evan Wallace
 # Released under the MIT license
 
+import math
 import re
 import moderngl
 from typing import Self
@@ -17,7 +18,7 @@ class Matrices:
         self._model = model or glm.identity(glm.mat4)
         self.view = view or glm.lookAt(
             (1.0, 1.0, 1.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
-        self.projection = projection or glm.perspective(45.0, 1.0, 0.1, 1000.0)
+        self.projection = projection or glm.perspective(math.radians(60.0), 1.0, 0.1, 1000.0)
 
     @property
     def normal(self) -> glm.mat4:

--- a/examples/water/water_main.py
+++ b/examples/water/water_main.py
@@ -83,7 +83,7 @@ class WaterMain(mglw.WindowConfig):
         self.angle_y = 30
 
         self.matrices = Matrices(glm.translate((0.0, 0.5, 0.0)), glm.lookAt(self.eye, (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)), glm.perspective(
-            45, self.aspect_ratio, 0.01, 100))
+            math.radians(60.0), self.aspect_ratio, 0.01, 100))
         self.renderer = Renderer(self.ctx)
         self.water = Water(ctx=self.ctx)
         self.center = glm.vec3(-0.4, -0.75, 0.2)

--- a/examples/water/water_sim.py
+++ b/examples/water/water_sim.py
@@ -55,7 +55,7 @@ class WaterSimulation(mglw.WindowConfig):
     def on_render(self, time, frame_time):
         angle = time * 0.2
         self.matrix.projection = glm.perspective(
-            45.0, self.aspect_ratio, 0.1, 1000.0)
+            math.radians(60.0), self.aspect_ratio, 0.1, 1000.0)
         self.matrix.view = glm.lookAt((np.cos(angle), np.sin(angle), 2.2),
                                       (0.0, 0.0, 0.0),
                                       (0.0, 0.0, 1.0),)


### PR DESCRIPTION
Unlike the old `Matrix44.perspective_projection`, `glm.perspective` expects its field of view argument in radians, not degrees as were implied by the magnitude of 45.

Fix by using Python's built in radians conversion function. 45 radians corresponds (wrapped) to 58.31 degrees so the field of view is specified as 60 degrees to produce a negligible change in example output.