### PR TITLE
Find versionless libEGL.so and libGL.so without installed dev package

### DIFF
--- a/_moderngl.py
+++ b/_moderngl.py
@@ -197,6 +197,8 @@ class DefaultLoader:
         import ctypes
         import sys
 
+        from ctypes.util import find_library
+
         def funcptr(lib, name):
             return ctypes.cast(getattr(lib, name, 0), ctypes.c_void_p).value or 0
 
@@ -211,7 +213,11 @@ class DefaultLoader:
 
         elif sys.platform.startswith("linux"):
             try:
-                lib = ctypes.CDLL("libEGL.so")
+                libegl = find_library("EGL")
+                if libegl is None:
+                    raise RuntimeError("Cannot find OpenGL support library libEGL")
+
+                lib = ctypes.CDLL(libegl)
                 proc = ctypes.cast(lib.eglGetProcAddress, ctypes.CFUNCTYPE(ctypes.c_ulonglong, ctypes.c_char_p))
                 if not lib.eglGetCurrentContext():
                     raise RuntimeError("Cannot detect window with OpenGL support")
@@ -220,7 +226,11 @@ class DefaultLoader:
                     return proc(name.encode())
 
             except:
-                lib = ctypes.CDLL("libGL.so")
+                libgl = find_library('GL')
+                if libgl is None:
+                    raise RuntimeError("Cannot find OpenGL support library libGL")
+
+                lib = ctypes.CDLL(libgl)
                 proc = ctypes.cast(lib.glXGetProcAddress, ctypes.CFUNCTYPE(ctypes.c_ulonglong, ctypes.c_char_p))
                 if not lib.glXGetCurrentContext():
                     raise RuntimeError("Cannot detect window with OpenGL support")


### PR DESCRIPTION
As asked about [here](https://discord.com/channels/550302843777712148/550303740239020052/1432179901351465073)
Additional context: [symlinks and .so files on linux - what you need to know](https://dmerej.info/blog/post/symlinks-and-so-files-on-linux/)

On linux systems without an `-devel` package, the symlinks for unversioned library access are often(?) not available, and `-devel` packages are not installed by default on most distros.

So on a fresh install, both moderngl and glcontext are not able to find the unversioned `libEGL.so`, `libGL.so`, and `libX11.so`.

To deal with that, I first patched moderngl to use python's `ctypes.util.find_library`, which looks at what the dynamic linker has available when given a base name.

Since moderngl's test suite relies heavily on glcontext, I had to port that functionality to over there as well.

glcontext is written in C, and a "find" function for dynamic libraries does not exist, thus the solution here is more limited and inflexible.  It tries both the versioned and unversioned names for all modules that use `dlopen`.

On my system, both glcontext and moderngl test successfully.

In the process I also removed a few warnings and made the error messages about loading the shared libraries between `glcontext.egl` and `glcontext.x11` more consistent.

Sadly, glcontext is not part of moderngl, so two PRs are needed, and checks of moderngl won't pass until the functionality is in glcontext first.

Besides functionality checks, if any of this breaks style guides, please let me know.