### PR TITLE
Add support for additional texture wrapping modes

### DIFF
--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -612,6 +612,21 @@ class Renderbuffer:
             self.mglo.release()
             self.mglo = InvalidObject()
 
+# A proxy object returned for the wrap property for Sampler, Texture, Texture3D and TextureArray
+class WrapProxy:
+    def __init__(self, mglo):
+        self._mglo = mglo
+    def __getitem__(self, k):
+        return self._mglo.wrap.get(k)
+    def __setitem__(self, k, v):
+        self._mglo.wrap = {k: v}
+    def __delitem__(self, k):
+        pass
+    def __iter__(self):
+        return iter(self._mglo.wrap.keys())
+    def __len__(self):
+        return self._mglo.wrap.size()
+    def keys(self): return list(iter(self._mglo.wrap.keys()))
 
 class Sampler:
     def __init__(self):
@@ -668,6 +683,14 @@ class Sampler:
     @repeat_z.setter
     def repeat_z(self, value):
         self.mglo.repeat_z = value
+
+    @property
+    def wrap(self):
+        return WrapProxy(self.mglo)
+
+    @wrap.setter
+    def wrap(self, value):
+        self.mglo.wrap = value
 
     @property
     def filter(self):
@@ -817,6 +840,14 @@ class Texture:
     @repeat_y.setter
     def repeat_y(self, value):
         self.mglo.repeat_y = value
+
+    @property
+    def wrap(self):
+        return WrapProxy(self.mglo)
+
+    @wrap.setter
+    def wrap(self, value):
+        self.mglo.wrap = value
 
     @property
     def filter(self):
@@ -979,6 +1010,14 @@ class Texture3D:
     @repeat_z.setter
     def repeat_z(self, value):
         self.mglo.repeat_z = value
+
+    @property
+    def wrap(self):
+        return WrapProxy(self.mglo)
+
+    @wrap.setter
+    def wrap(self, value):
+        self.mglo.wrap = value
 
     @property
     def filter(self):
@@ -1240,6 +1279,14 @@ class TextureArray:
     @repeat_y.setter
     def repeat_y(self, value):
         self.mglo.repeat_y = value
+
+    @property
+    def wrap(self):
+        return WrapProxy(self.mglo)
+
+    @wrap.setter
+    def wrap(self, value):
+        self.mglo.wrap = value
 
     @property
     def filter(self):

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -625,7 +625,7 @@ class WrapProxy:
     def __iter__(self):
         return iter(self._mglo.wrap.keys())
     def __len__(self):
-        return self._mglo.wrap.size()
+        return len(self._mglo.wrap)
     def keys(self): return list(iter(self._mglo.wrap.keys()))
 
 class Sampler:

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -620,8 +620,6 @@ class WrapProxy:
         return self._mglo.wrap.get(k)
     def __setitem__(self, k, v):
         self._mglo.wrap = {k: v}
-    def __delitem__(self, k):
-        pass
     def __iter__(self):
         return iter(self._mglo.wrap.keys())
     def __len__(self):

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -612,6 +612,8 @@ class Renderbuffer:
             self.mglo.release()
             self.mglo = InvalidObject()
 
+_WRAP_SYNONYMS = {'x': 's', 'y': 't', 'z': 'r'}
+
 # A proxy object returned for the wrap property for Sampler, Texture, Texture3D and TextureArray
 class WrapProxy:
     def __init__(self, mglo):
@@ -619,6 +621,10 @@ class WrapProxy:
     def __getitem__(self, k):
         return self._mglo.wrap.get(k)
     def __setitem__(self, k, v):
+        canonical = self._mglo.wrap.keys()
+        valid = set(canonical) | {_WRAP_SYNONYMS[c] for c in canonical}
+        if k not in valid:
+            raise KeyError(k)
         self._mglo.wrap = {k: v}
     def __iter__(self):
         return iter(self._mglo.wrap.keys())

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -618,19 +618,25 @@ _WRAP_SYNONYMS = {'x': 's', 'y': 't', 'z': 'r'}
 class WrapProxy:
     def __init__(self, mglo):
         self._mglo = mglo
+
     def __getitem__(self, k):
         return self._mglo.wrap.get(k)
+
     def __setitem__(self, k, v):
         canonical = self._mglo.wrap.keys()
         valid = set(canonical) | {_WRAP_SYNONYMS[c] for c in canonical}
         if k not in valid:
             raise KeyError(k)
         self._mglo.wrap = {k: v}
+
     def __iter__(self):
         return iter(self._mglo.wrap.keys())
+
     def __len__(self):
         return len(self._mglo.wrap)
-    def keys(self): return list(iter(self._mglo.wrap.keys()))
+
+    def keys(self):
+        return list(self._mglo.wrap.keys())
 
 class Sampler:
     def __init__(self):

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -9557,7 +9557,7 @@ static PyGetSetDef MGLTextureArray_getset[] = {
     {(char *)"repeat_x", (getter)MGLTextureArray_get_repeat_x, (setter)MGLTextureArray_set_repeat_x},
     {(char *)"repeat_y", (getter)MGLTextureArray_get_repeat_y, (setter)MGLTextureArray_set_repeat_y},
     {(char *)"wrap", (getter)MGLTextureArray_get_wrap, (setter)MGLTextureArray_set_wrap},
-   {(char *)"filter", (getter)MGLTextureArray_get_filter, (setter)MGLTextureArray_set_filter},
+    {(char *)"filter", (getter)MGLTextureArray_get_filter, (setter)MGLTextureArray_set_filter},
     {(char *)"swizzle", (getter)MGLTextureArray_get_swizzle, (setter)MGLTextureArray_set_swizzle},
     {(char *)"anisotropy", (getter)MGLTextureArray_get_anisotropy, (setter)MGLTextureArray_set_anisotropy},
     {},

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -1,5 +1,7 @@
 #define PY_SSIZE_T_CLEAN
+#include <functional>
 #include <Python.h>
+#include <string>
 
 #include "gl_methods.hpp"
 
@@ -329,8 +331,8 @@ struct MGLTexture {
     int compare_func;
     float anisotropy;
     bool depth;
-    bool repeat_x;
-    bool repeat_y;
+    int wrap_s;
+    int wrap_t;
     bool external;
     bool released;
 };
@@ -347,9 +349,9 @@ struct MGLTexture3D {
     int min_filter;
     int mag_filter;
     int max_level;
-    bool repeat_x;
-    bool repeat_y;
-    bool repeat_z;
+    int wrap_s;
+    int wrap_t;
+    int wrap_r;
     bool released;
 };
 
@@ -365,8 +367,8 @@ struct MGLTextureArray {
     int min_filter;
     int mag_filter;
     int max_level;
-    bool repeat_x;
-    bool repeat_y;
+    int wrap_s;
+    int wrap_t;
     float anisotropy;
     bool released;
 };
@@ -409,9 +411,9 @@ struct MGLSampler {
     int mag_filter;
     float anisotropy;
     int compare_func;
-    bool repeat_x;
-    bool repeat_y;
-    bool repeat_z;
+    int wrap_s;
+    int wrap_t;
+    int wrap_r;
     float border_color[4];
     float min_lod;
     float max_lod;
@@ -2992,9 +2994,9 @@ static PyObject * MGLContext_sampler(MGLContext * self, PyObject * args) {
     sampler->min_filter = GL_LINEAR;
     sampler->mag_filter = GL_LINEAR;
     sampler->anisotropy = 0.0;
-    sampler->repeat_x = true;
-    sampler->repeat_y = true;
-    sampler->repeat_z = true;
+    sampler->wrap_s = GL_REPEAT;
+    sampler->wrap_t = GL_REPEAT;
+    sampler->wrap_r = GL_REPEAT;
     sampler->compare_func = 0;
     sampler->border_color[0] = 0.0;
     sampler->border_color[1] = 0.0;
@@ -3075,68 +3077,197 @@ static PyObject * MGLSampler_release(MGLSampler * self, PyObject * args) {
     Py_RETURN_NONE;
 }
 
+static const char * wrap_constant_to_string(const int wrap_constant) {
+    switch (wrap_constant) {
+        case GL_REPEAT: return "repeat";
+        case GL_CLAMP_TO_EDGE: return "clamp_to_edge";
+        case GL_CLAMP_TO_BORDER: return "clamp_to_border";
+        case GL_MIRRORED_REPEAT: return "mirrored_repeat";
+        case GL_MIRROR_CLAMP_TO_EDGE: return "mirror_clamp_to_edge";
+        default: return "unknown";
+    }
+}
+
+static int wrap_string_to_constant(const char * wrap_string) {
+    if (!strcmp(wrap_string, "repeat")) return GL_REPEAT;
+    if (!strcmp(wrap_string, "clamp_to_edge")) return GL_CLAMP_TO_EDGE;
+    if (!strcmp(wrap_string, "clamp_to_border")) return GL_CLAMP_TO_BORDER;
+    if (!strcmp(wrap_string, "mirrored_repeat")) return GL_MIRRORED_REPEAT;
+    if (!strcmp(wrap_string, "mirror_clamp_to_edge")) return GL_MIRROR_CLAMP_TO_EDGE;
+    return 0; // Invalid
+}
+
+// Helper function to get a texture wrapping mode
+static int GetWrapMode(PyObject * wrap_dict, const char* key, const int mode)
+{
+    PyObject * wrap_mode_str = PyUnicode_FromString(wrap_constant_to_string(mode));
+
+    if (!wrap_mode_str ) {
+        return -1;
+    }
+
+    PyDict_SetItemString(wrap_dict, key, wrap_mode_str);
+
+    Py_DECREF(wrap_mode_str);
+    return 0;
+}
+
+using GLMethodPtr = void(*)(GLuint, GLenum, GLint);
+
+// Helper function to set a texture wrapping mode
+static int SetWrapMode(const GLMethodPtr gl_method, const int field, PyObject* update_dict,
+                       const char* key, const char* synonym_key, const GLenum pname, int* wrap_mode)
+{
+    PyObject* wrap_obj = PyDict_GetItemString(update_dict, key);
+    PyObject* synonym_wrap_obj = PyDict_GetItemString(update_dict, synonym_key);
+    if (!wrap_obj && !synonym_wrap_obj)
+    {
+        return 0; // Okay for neither to exist
+    }
+    // If either key is given, then the value must be a string
+    for (const auto& [k, v] : {
+             std::make_pair(key, wrap_obj), std::make_pair(synonym_key, synonym_wrap_obj)
+         })
+    {
+        if (v && !PyUnicode_Check(v))
+        {
+            MGLError_Set(("Value for key "+ std::string(k) + " must be a string").c_str());
+            return -1;
+        }
+    }
+    // If both exist, the values must be the same
+    if (wrap_obj && synonym_wrap_obj && PyUnicode_Compare(wrap_obj, synonym_wrap_obj) != 0)
+    {
+        MGLError_Set(
+            (" Both the key '"+ std::string(key) + "' and its synonym '"+ std::string(synonym_key) +
+                "' were given, but with different values").c_str());
+        return -1;
+    }
+
+    // Either the key or its synonym have been supplied
+    const char* & key_used = key;
+    if (!wrap_obj)
+    {
+        wrap_obj = synonym_wrap_obj;
+        key_used = synonym_key;
+    }
+    const char* wrap_str = PyUnicode_AsUTF8(wrap_obj);
+    const int wrap_constant = wrap_string_to_constant(wrap_str);
+    if (!wrap_constant)
+    {
+        MGLError_Set(("invalid wrap mode for '" + std::string(key_used) + "'").c_str());
+        return -1;
+    }
+    gl_method(field, pname, wrap_constant);
+    *wrap_mode = wrap_constant;
+
+    return 0;
+}
+
+static PyObject * MGLSampler_get_wrap(const MGLSampler * self, void * closure) {
+    PyObject * wrap_dict = PyDict_New();
+    if (!wrap_dict) {
+        return nullptr;
+    }
+
+    // Use the "x", "y", "z" keys to be consistent with other usage in moderngl
+    std::vector<std::tuple<const char*,int>> wrap_fields = {
+        {"x", self->wrap_s},
+        {"y", self->wrap_t},
+        {"z", self->wrap_r}
+    };
+    for (const auto [key, field_value] : wrap_fields)
+    {
+        if (GetWrapMode(wrap_dict, key, field_value))
+        {
+            Py_DECREF(wrap_dict);
+            return nullptr;
+        }
+    }
+
+    return wrap_dict;
+}
+
+
+static int MGLSampler_set_wrap(MGLSampler * self, PyObject * value, void * closure) {
+    const GLMethods & gl = self->context->gl;
+
+    if (!PyDict_Check(value)) {
+        MGLError_Set("wrap must be a dictionary");
+        return -1;
+    }
+
+    std::vector<std::tuple<const char*, const char*, GLenum, int*>> known_keys = {
+        {"x", "s", GL_TEXTURE_WRAP_S, &self->wrap_s},
+        {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
+        {"z", "r", GL_TEXTURE_WRAP_R, &self->wrap_r}
+    };
+    for (const auto [key, synonym_key, pname, field_ptr] : known_keys)
+    {
+        // Process key if present
+        if (const auto return_value = SetWrapMode(gl.SamplerParameteri, self->sampler_obj,
+                                                       value, key, synonym_key, pname, field_ptr))
+        {
+            return return_value;
+        }
+    }
+
+    return 0;
+}
+
+template <class T>
+using SetFunctionPtr = int(*)(T*, PyObject*, void*);
+
+// Helper function to set the repeat texture wrap value
+template <class T>
+static int set_repeat_value(T* self, const SetFunctionPtr<T> set_function, const PyObject* value,
+                            const char* key_string, void* closure)
+{
+    PyObject* dict = PyDict_New();
+    PyObject* key = PyUnicode_FromString(key_string);
+    PyObject* str_value = (value == Py_True)
+                              ? PyUnicode_FromString("repeat")
+                              : (value == Py_False)
+                              ? PyUnicode_FromString("clamp_to_edge")
+                              : nullptr;
+    if (!str_value)
+    {
+        MGLError_Set((std::string("invalid value for texture_") + std::string(key_string)).c_str());
+        return -1;
+    }
+    PyDict_SetItem(dict, key, str_value);
+
+    const int return_value = set_function(self, dict, closure);
+    Py_DECREF(str_value);
+    Py_DECREF(key);
+    Py_DECREF(dict);
+    return return_value;
+}
+
 static PyObject * MGLSampler_get_repeat_x(MGLSampler * self, void * closure) {
-    return PyBool_FromLong(self->repeat_x);
+    return self->wrap_s == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLSampler_set_repeat_x(MGLSampler * self, PyObject * value, void * closure) {
-    const GLMethods & gl = self->context->gl;
-
-    if (value == Py_True) {
-        gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_WRAP_S, GL_REPEAT);
-        self->repeat_x = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        self->repeat_x = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_x");
-        return -1;
-    }
+    return set_repeat_value(self, MGLSampler_set_wrap, value, "x", closure);
 }
 
 static PyObject * MGLSampler_get_repeat_y(MGLSampler * self, void * closure) {
-    return PyBool_FromLong(self->repeat_y);
+    return self->wrap_t == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLSampler_set_repeat_y(MGLSampler * self, PyObject * value, void * closure) {
-    const GLMethods & gl = self->context->gl;
-
-    if (value == Py_True) {
-        gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_WRAP_T, GL_REPEAT);
-        self->repeat_y = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        self->repeat_y = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_y");
-        return -1;
-    }
+    return set_repeat_value(self, MGLSampler_set_wrap, value, "y", closure);
 }
 
 static PyObject * MGLSampler_get_repeat_z(MGLSampler * self, void * closure) {
-    return PyBool_FromLong(self->repeat_z);
+    return self->wrap_r == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLSampler_set_repeat_z(MGLSampler * self, PyObject * value, void * closure) {
-    const GLMethods & gl = self->context->gl;
-
-    if (value == Py_True) {
-        gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_WRAP_R, GL_REPEAT);
-        self->repeat_z = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-        self->repeat_z = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_z");
-        return -1;
-    }
+    return set_repeat_value(self, MGLSampler_set_wrap, value, "z", closure);
 }
+
 
 static PyObject * MGLSampler_get_filter(MGLSampler * self, void * closure) {
     return Py_BuildValue("(ii)", self->min_filter, self->mag_filter);
@@ -3813,8 +3944,8 @@ static PyObject * MGLContext_texture(MGLContext * self, PyObject * args) {
     texture->min_filter = data_type->float_type ? GL_LINEAR : GL_NEAREST;
     texture->mag_filter = data_type->float_type ? GL_LINEAR : GL_NEAREST;
 
-    texture->repeat_x = true;
-    texture->repeat_y = true;
+    texture->wrap_s = GL_REPEAT;
+    texture->wrap_t = GL_REPEAT;
 
     Py_INCREF(self);
     texture->context = self;
@@ -3974,8 +4105,8 @@ static PyObject * MGLContext_depth_texture(MGLContext * self, PyObject * args) {
     texture->mag_filter = GL_LINEAR;
     texture->max_level = 0;
 
-    texture->repeat_x = false;
-    texture->repeat_y = false;
+    texture->wrap_s = GL_CLAMP_TO_EDGE;
+    texture->wrap_t = GL_CLAMP_TO_EDGE;
 
     Py_INCREF(self);
     texture->context = self;
@@ -4032,8 +4163,8 @@ static PyObject * MGLContext_external_texture(MGLContext * self, PyObject * args
     texture->min_filter = data_type->float_type ? GL_LINEAR : GL_NEAREST;
     texture->mag_filter = data_type->float_type ? GL_LINEAR : GL_NEAREST;
 
-    texture->repeat_x = true;
-    texture->repeat_y = true;
+    texture->wrap_s = GL_REPEAT;
+    texture->wrap_t = GL_REPEAT;
 
     Py_INCREF(self);
     texture->context = self;
@@ -4446,56 +4577,70 @@ static PyObject * MGLTexture_release(MGLTexture * self, PyObject * args) {
     Py_RETURN_NONE;
 }
 
+
+static PyObject * MGLTexture_get_wrap(const MGLTexture * self, void * closure) {
+    PyObject * wrap_dict = PyDict_New();
+    if (!wrap_dict) {
+        return nullptr;
+    }
+
+    // Use the "x", "y" keys to be consistent with other usage in moderngl
+    std::vector<std::tuple<const char*,int>> wrap_fields = {
+        {"x", self->wrap_s},
+        {"y", self->wrap_t},
+    };
+    for (const auto [key, field_value] : wrap_fields)
+    {
+        if (GetWrapMode(wrap_dict, key, field_value))
+        {
+            Py_DECREF(wrap_dict);
+            return nullptr;
+        }
+    }
+
+    return wrap_dict;
+}
+
+static int MGLTexture_set_wrap(MGLTexture * self, PyObject * value, void * closure) {
+    const GLMethods & gl = self->context->gl;
+
+    if (!PyDict_Check(value)) {
+        MGLError_Set("wrap must be a dictionary");
+        return -1;
+    }
+    const int texture_target = self->samples ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
+
+    std::vector<std::tuple<const char*, const char*, GLint, int*>> known_keys = {
+        {"x", "s", GL_TEXTURE_WRAP_S, &self->wrap_s},
+        {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
+    };
+    for (const auto [key, synonym_key, pname, field_ptr] : known_keys)
+    {
+        // Process key if present
+        if (const auto return_value = SetWrapMode(gl.TexParameteri, texture_target, value, key,
+                                                       synonym_key, pname, field_ptr))
+        {
+            return return_value;
+        }
+    }
+
+    return 0;
+}
+
 static PyObject * MGLTexture_get_repeat_x(MGLTexture * self, void * closure) {
-    return PyBool_FromLong(self->repeat_x);
+    return self->wrap_s == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLTexture_set_repeat_x(MGLTexture * self, PyObject * value, void * closure) {
-    int texture_target = self->samples ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
-
-    const GLMethods & gl = self->context->gl;
-
-    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
-    gl.BindTexture(texture_target, self->texture_obj);
-
-    if (value == Py_True) {
-        gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_REPEAT);
-        self->repeat_x = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        self->repeat_x = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_x");
-        return -1;
-    }
+    return set_repeat_value(self, MGLTexture_set_wrap, value, "x", closure);
 }
 
 static PyObject * MGLTexture_get_repeat_y(MGLTexture * self, void * closure) {
-    return PyBool_FromLong(self->repeat_y);
+    return self->wrap_t == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLTexture_set_repeat_y(MGLTexture * self, PyObject * value, void * closure) {
-    int texture_target = self->samples ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
-
-    const GLMethods & gl = self->context->gl;
-
-    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
-    gl.BindTexture(texture_target, self->texture_obj);
-
-    if (value == Py_True) {
-        gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_REPEAT);
-        self->repeat_y = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        self->repeat_y = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_y");
-        return -1;
-    }
+    return set_repeat_value(self, MGLTexture_set_wrap, value, "y", closure);
 }
 
 static PyObject * MGLTexture_get_filter(MGLTexture * self, void * closure) {
@@ -4777,9 +4922,9 @@ static PyObject * MGLContext_texture3d(MGLContext * self, PyObject * args) {
     texture->mag_filter = data_type->float_type ? GL_LINEAR : GL_NEAREST;
     texture->max_level = 0;
 
-    texture->repeat_x = true;
-    texture->repeat_y = true;
-    texture->repeat_z = true;
+    texture->wrap_s = GL_REPEAT;
+    texture->wrap_t = GL_REPEAT;
+    texture->wrap_r = GL_REPEAT;
 
     Py_INCREF(self);
     texture->context = self;
@@ -5118,79 +5263,79 @@ static PyObject * MGLTexture3D_release(MGLTexture3D * self, PyObject * args) {
     Py_RETURN_NONE;
 }
 
+
+static PyObject *MGLTexture3D_get_wrap(const MGLTexture3D * self, void * closure) {
+    PyObject * wrap_dict = PyDict_New();
+    if (!wrap_dict) {
+        return nullptr;
+    }
+
+    // Use the "x", "y", "z" keys to be consistent with other usage in moderngl
+    std::vector<std::tuple<const char*,int>> wrap_fields = {
+        {"x", self->wrap_s},
+        {"y", self->wrap_t},
+        {"z", self->wrap_r}
+    };
+    for (const auto [key, field_value] : wrap_fields)
+    {
+        if (GetWrapMode(wrap_dict, key, field_value))
+        {
+            Py_DECREF(wrap_dict);
+            return nullptr;
+        }
+    }
+
+    return wrap_dict;
+}
+
+static int MGLTexture3D_set_wrap(MGLTexture3D * self, PyObject * value, void * closure) {
+    const GLMethods & gl = self->context->gl;
+
+    if (!PyDict_Check(value)) {
+        MGLError_Set("wrap must be a dictionary");
+        return -1;
+    }
+
+    std::vector<std::tuple<const char*, const char*, GLenum, int*>> known_keys = {
+        {"x", "s", GL_TEXTURE_WRAP_S, &self->wrap_s},
+        {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
+        {"z", "r", GL_TEXTURE_WRAP_R, &self->wrap_r},
+    };
+    for (const auto [key, synonym_key, pname, field_ptr] : known_keys)
+    {
+        // Process key if present
+        if (const auto return_value = SetWrapMode(gl.TexParameteri, GL_TEXTURE_3D, value, key,
+                                                       synonym_key, pname, field_ptr))
+        {
+            return return_value;
+        }
+    }
+
+    return 0;
+}
+
 static PyObject * MGLTexture3D_get_repeat_x(MGLTexture3D * self, void * closure) {
-    return PyBool_FromLong(self->repeat_x);
+    return self->wrap_s == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLTexture3D_set_repeat_x(MGLTexture3D * self, PyObject * value, void * closure) {
-
-    const GLMethods & gl = self->context->gl;
-
-    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
-    gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
-
-    if (value == Py_True) {
-        gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-        self->repeat_x = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        self->repeat_x = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_x");
-        return -1;
-    }
+    return set_repeat_value(self, MGLTexture3D_set_wrap, value, "x", closure);
 }
 
 static PyObject * MGLTexture3D_get_repeat_y(MGLTexture3D * self, void * closure) {
-    return PyBool_FromLong(self->repeat_y);
+    return self->wrap_t == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLTexture3D_set_repeat_y(MGLTexture3D * self, PyObject * value, void * closure) {
-
-    const GLMethods & gl = self->context->gl;
-
-    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
-    gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
-
-    if (value == Py_True) {
-        gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-        self->repeat_y = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        self->repeat_y = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_y");
-        return -1;
-    }
+    return set_repeat_value(self, MGLTexture3D_set_wrap, value, "y", closure);
 }
 
 static PyObject * MGLTexture3D_get_repeat_z(MGLTexture3D * self, void * closure) {
-    return PyBool_FromLong(self->repeat_z);
+    return self->wrap_r == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLTexture3D_set_repeat_z(MGLTexture3D * self, PyObject * value, void * closure) {
-
-    const GLMethods & gl = self->context->gl;
-
-    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
-    gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
-
-    if (value == Py_True) {
-        gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_REPEAT);
-        self->repeat_z = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-        self->repeat_z = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_z");
-        return -1;
-    }
+    return set_repeat_value(self, MGLTexture3D_set_wrap, value, "z", closure);
 }
 
 static PyObject * MGLTexture3D_get_filter(MGLTexture3D * self, void * closure) {
@@ -5402,8 +5547,8 @@ static PyObject * MGLContext_texture_array(MGLContext * self, PyObject * args) {
     texture->min_filter = data_type->float_type ? GL_LINEAR : GL_NEAREST;
     texture->mag_filter = data_type->float_type ? GL_LINEAR : GL_NEAREST;
 
-    texture->repeat_x = true;
-    texture->repeat_y = true;
+    texture->wrap_s = GL_REPEAT;
+    texture->wrap_t = GL_REPEAT;
     texture->anisotropy = 0.0;
     texture->max_level = 0;
 
@@ -5767,54 +5912,68 @@ static PyObject * MGLTextureArray_release(MGLTextureArray * self, PyObject * arg
     Py_RETURN_NONE;
 }
 
+static PyObject * MGLTextureArray_get_wrap(const MGLTextureArray * self, void * closure) {
+    PyObject * wrap_dict = PyDict_New();
+    if (!wrap_dict) {
+        return nullptr;
+    }
+
+    // Use the "x", "y" keys to be consistent with other usage in moderngl
+    std::vector<std::tuple<const char*,int>> wrap_fields = {
+        {"x", self->wrap_s},
+        {"y", self->wrap_t},
+    };
+    for (const auto [key, field_value] : wrap_fields)
+    {
+        if (GetWrapMode(wrap_dict, key, field_value))
+        {
+            Py_DECREF(wrap_dict);
+            return nullptr;
+        }
+    }
+
+    return wrap_dict;
+}
+
+static int MGLTextureArray_set_wrap(MGLTextureArray * self, PyObject * value, void * closure) {
+    const GLMethods & gl = self->context->gl;
+
+    if (!PyDict_Check(value)) {
+        MGLError_Set("wrap must be a dictionary");
+        return -1;
+    }
+
+    std::vector<std::tuple<const char*, const char*, GLint, int*>> known_keys = {
+        {"x", "s", GL_TEXTURE_WRAP_S, &self->wrap_s},
+        {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
+    };
+    for (const auto [key, synonym_key, pname, field_ptr] : known_keys)
+    {
+        // Process key if present
+        if (const auto return_value = SetWrapMode(gl.TexParameteri, GL_TEXTURE_2D_ARRAY, value,
+                                                   key, synonym_key, pname, field_ptr))
+        {
+            return return_value;
+        }
+    }
+
+    return 0;
+}
+
 static PyObject * MGLTextureArray_get_repeat_x(MGLTextureArray * self, void * closure) {
-    return PyBool_FromLong(self->repeat_x);
+    return self->wrap_s == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLTextureArray_set_repeat_x(MGLTextureArray * self, PyObject * value, void * closure) {
-
-    const GLMethods & gl = self->context->gl;
-
-    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
-    gl.BindTexture(GL_TEXTURE_2D_ARRAY, self->texture_obj);
-
-    if (value == Py_True) {
-        gl.TexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_REPEAT);
-        self->repeat_x = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.TexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        self->repeat_x = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_x");
-        return -1;
-    }
+    return set_repeat_value(self, MGLTextureArray_set_wrap, value, "x", closure);
 }
 
 static PyObject * MGLTextureArray_get_repeat_y(MGLTextureArray * self, void * closure) {
-    return PyBool_FromLong(self->repeat_y);
+    return self->wrap_t == GL_REPEAT ? Py_True : Py_False;
 }
 
 static int MGLTextureArray_set_repeat_y(MGLTextureArray * self, PyObject * value, void * closure) {
-
-    const GLMethods & gl = self->context->gl;
-
-    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
-    gl.BindTexture(GL_TEXTURE_2D_ARRAY, self->texture_obj);
-
-    if (value == Py_True) {
-        gl.TexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_REPEAT);
-        self->repeat_y = true;
-        return 0;
-    } else if (value == Py_False) {
-        gl.TexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        self->repeat_y = false;
-        return 0;
-    } else {
-        MGLError_Set("invalid value for texture_y");
-        return -1;
-    }
+    return set_repeat_value(self, MGLTextureArray_set_wrap, value, "y", closure);
 }
 
 static PyObject * MGLTextureArray_get_filter(MGLTextureArray * self, void * closure) {
@@ -9316,6 +9475,7 @@ static PyGetSetDef MGLSampler_getset[] = {
     {(char *)"repeat_x", (getter)MGLSampler_get_repeat_x, (setter)MGLSampler_set_repeat_x},
     {(char *)"repeat_y", (getter)MGLSampler_get_repeat_y, (setter)MGLSampler_set_repeat_y},
     {(char *)"repeat_z", (getter)MGLSampler_get_repeat_z, (setter)MGLSampler_set_repeat_z},
+    {(char *)"wrap", (getter)MGLSampler_get_wrap, (setter)MGLSampler_set_wrap},
     {(char *)"filter", (getter)MGLSampler_get_filter, (setter)MGLSampler_set_filter},
     {(char *)"compare_func", (getter)MGLSampler_get_compare_func, (setter)MGLSampler_set_compare_func},
     {(char *)"anisotropy", (getter)MGLSampler_get_anisotropy, (setter)MGLSampler_set_anisotropy},
@@ -9342,6 +9502,7 @@ static PyMethodDef MGLScope_methods[] = {
 static PyGetSetDef MGLTexture_getset[] = {
     {(char *)"repeat_x", (getter)MGLTexture_get_repeat_x, (setter)MGLTexture_set_repeat_x},
     {(char *)"repeat_y", (getter)MGLTexture_get_repeat_y, (setter)MGLTexture_set_repeat_y},
+    {(char *)"wrap", (getter)MGLTexture_get_wrap, (setter)MGLTexture_set_wrap},
     {(char *)"filter", (getter)MGLTexture_get_filter, (setter)MGLTexture_set_filter},
     {(char *)"swizzle", (getter)MGLTexture_get_swizzle, (setter)MGLTexture_set_swizzle},
     {(char *)"compare_func", (getter)MGLTexture_get_compare_func, (setter)MGLTexture_set_compare_func},
@@ -9365,6 +9526,7 @@ static PyGetSetDef MGLTexture3D_getset[] = {
     {(char *)"repeat_x", (getter)MGLTexture3D_get_repeat_x, (setter)MGLTexture3D_set_repeat_x},
     {(char *)"repeat_y", (getter)MGLTexture3D_get_repeat_y, (setter)MGLTexture3D_set_repeat_y},
     {(char *)"repeat_z", (getter)MGLTexture3D_get_repeat_z, (setter)MGLTexture3D_set_repeat_z},
+    {(char *)"wrap", (getter)MGLTexture3D_get_wrap, (setter)MGLTexture3D_set_wrap},
     {(char *)"filter", (getter)MGLTexture3D_get_filter, (setter)MGLTexture3D_set_filter},
     {(char *)"swizzle", (getter)MGLTexture3D_get_swizzle, (setter)MGLTexture3D_set_swizzle},
     {},
@@ -9385,7 +9547,8 @@ static PyMethodDef MGLTexture3D_methods[] = {
 static PyGetSetDef MGLTextureArray_getset[] = {
     {(char *)"repeat_x", (getter)MGLTextureArray_get_repeat_x, (setter)MGLTextureArray_set_repeat_x},
     {(char *)"repeat_y", (getter)MGLTextureArray_get_repeat_y, (setter)MGLTextureArray_set_repeat_y},
-    {(char *)"filter", (getter)MGLTextureArray_get_filter, (setter)MGLTextureArray_set_filter},
+    {(char *)"wrap", (getter)MGLTextureArray_get_wrap, (setter)MGLTextureArray_set_wrap},
+   {(char *)"filter", (getter)MGLTextureArray_get_filter, (setter)MGLTextureArray_set_filter},
     {(char *)"swizzle", (getter)MGLTextureArray_get_swizzle, (setter)MGLTextureArray_set_swizzle},
     {(char *)"anisotropy", (getter)MGLTextureArray_get_anisotropy, (setter)MGLTextureArray_set_anisotropy},
     {},

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -3082,8 +3082,8 @@ static const char * wrap_constant_to_string(const int wrap_constant) {
         case GL_CLAMP_TO_BORDER: return "clamp_to_border";
         case GL_MIRRORED_REPEAT: return "mirrored_repeat";
         case GL_MIRROR_CLAMP_TO_EDGE: return "mirror_clamp_to_edge";
-        default: return "unknown";
     }
+    return nullptr;
 }
 
 static int wrap_string_to_constant(const char * wrap_string) {
@@ -3096,16 +3096,18 @@ static int wrap_string_to_constant(const char * wrap_string) {
 }
 
 // Helper function to get a texture wrapping mode
-static int GetWrapMode(PyObject * wrap_dict, const char* key, const int mode)
+static int get_wrap_mode(PyObject * wrap_dict, const char * key, const int mode)
 {
-    PyObject * wrap_mode_str = PyUnicode_FromString(wrap_constant_to_string(mode));
-
-    if (!wrap_mode_str ) {
+    const char * mode_string = wrap_constant_to_string(mode);
+    if (!mode_string) {
+        MGLError_Set("unrecognized wrap constant 0x%x for axis '%s'", mode, key);
         return -1;
     }
-
+    PyObject * wrap_mode_str = PyUnicode_FromString(mode_string);
+    if (!wrap_mode_str) {
+        return -1;
+    }
     PyDict_SetItemString(wrap_dict, key, wrap_mode_str);
-
     Py_DECREF(wrap_mode_str);
     return 0;
 }
@@ -3125,7 +3127,7 @@ struct WrapKey {
 };
 
 // Helper function to set a texture wrapping mode
-static int SetWrapMode(const GLMethodPtr gl_method, const int field, PyObject* update_dict,
+static int set_wrap_mode(const GLMethodPtr gl_method, const int field, PyObject* update_dict,
                        const char* key, const char* synonym_key, const GLenum pname, int* wrap_mode)
 {
     PyObject* wrap_obj = PyDict_GetItemString(update_dict, key);
@@ -3153,13 +3155,11 @@ static int SetWrapMode(const GLMethodPtr gl_method, const int field, PyObject* u
     }
 
     // Either the key or its synonym have been supplied
-    const char* & key_used = key;
-    if (!wrap_obj)
-    {
+    const char * key_used = wrap_obj ? key : synonym_key;
+    if (!wrap_obj) {
         wrap_obj = synonym_wrap_obj;
-        key_used = synonym_key;
     }
-    const char* wrap_str = PyUnicode_AsUTF8(wrap_obj);
+    const char * wrap_str = PyUnicode_AsUTF8(wrap_obj);
     const int wrap_constant = wrap_string_to_constant(wrap_str);
     if (!wrap_constant)
     {
@@ -3185,7 +3185,7 @@ static PyObject * MGLSampler_get_wrap(const MGLSampler * self, void * closure) {
         {"z", self->wrap_r},
     };
     for (const WrapField & wf : wrap_fields) {
-        if (GetWrapMode(wrap_dict, wf.key, wf.field_value)) {
+        if (get_wrap_mode(wrap_dict, wf.key, wf.field_value)) {
             Py_DECREF(wrap_dict);
             return nullptr;
         }
@@ -3209,7 +3209,7 @@ static int MGLSampler_set_wrap(MGLSampler * self, PyObject * value, void * closu
         {"z", "r", GL_TEXTURE_WRAP_R, &self->wrap_r},
     };
     for (const WrapKey & k : known_keys) {
-        if (const int return_value = SetWrapMode(gl.SamplerParameteri, self->sampler_obj,
+        if (const int return_value = set_wrap_mode(gl.SamplerParameteri, self->sampler_obj,
                                                   value, k.key, k.synonym_key, k.pname,
                                                   k.field_ptr)) {
             return return_value;
@@ -4611,7 +4611,7 @@ static PyObject * MGLTexture_get_wrap(const MGLTexture * self, void * closure) {
         {"y", self->wrap_t},
     };
     for (const WrapField & wf : wrap_fields) {
-        if (GetWrapMode(wrap_dict, wf.key, wf.field_value)) {
+        if (get_wrap_mode(wrap_dict, wf.key, wf.field_value)) {
             Py_DECREF(wrap_dict);
             return nullptr;
         }
@@ -4637,7 +4637,7 @@ static int MGLTexture_set_wrap(MGLTexture * self, PyObject * value, void * closu
         {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
     };
     for (const WrapKey & k : known_keys) {
-        if (const int return_value = SetWrapMode(gl.TexParameteri, texture_target, value,
+        if (const int return_value = set_wrap_mode(gl.TexParameteri, texture_target, value,
                                                   k.key, k.synonym_key, k.pname,
                                                   k.field_ptr)) {
             return return_value;
@@ -5290,7 +5290,7 @@ static PyObject * MGLTexture3D_release(MGLTexture3D * self, PyObject * args) {
 }
 
 
-static PyObject *MGLTexture3D_get_wrap(const MGLTexture3D * self, void * closure) {
+static PyObject * MGLTexture3D_get_wrap(const MGLTexture3D * self, void * closure) {
     PyObject * wrap_dict = PyDict_New();
     if (!wrap_dict) {
         return nullptr;
@@ -5303,7 +5303,7 @@ static PyObject *MGLTexture3D_get_wrap(const MGLTexture3D * self, void * closure
         {"z", self->wrap_r},
     };
     for (const WrapField & wf : wrap_fields) {
-        if (GetWrapMode(wrap_dict, wf.key, wf.field_value)) {
+        if (get_wrap_mode(wrap_dict, wf.key, wf.field_value)) {
             Py_DECREF(wrap_dict);
             return nullptr;
         }
@@ -5329,7 +5329,7 @@ static int MGLTexture3D_set_wrap(MGLTexture3D * self, PyObject * value, void * c
         {"z", "r", GL_TEXTURE_WRAP_R, &self->wrap_r},
     };
     for (const WrapKey & k : known_keys) {
-        if (const int return_value = SetWrapMode(gl.TexParameteri, GL_TEXTURE_3D, value,
+        if (const int return_value = set_wrap_mode(gl.TexParameteri, GL_TEXTURE_3D, value,
                                                   k.key, k.synonym_key, k.pname,
                                                   k.field_ptr)) {
             return return_value;
@@ -5955,7 +5955,7 @@ static PyObject * MGLTextureArray_get_wrap(const MGLTextureArray * self, void * 
         {"y", self->wrap_t},
     };
     for (const WrapField & wf : wrap_fields) {
-        if (GetWrapMode(wrap_dict, wf.key, wf.field_value)) {
+        if (get_wrap_mode(wrap_dict, wf.key, wf.field_value)) {
             Py_DECREF(wrap_dict);
             return nullptr;
         }
@@ -5980,7 +5980,7 @@ static int MGLTextureArray_set_wrap(MGLTextureArray * self, PyObject * value, vo
         {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
     };
     for (const WrapKey & k : known_keys) {
-        if (const int return_value = SetWrapMode(gl.TexParameteri, GL_TEXTURE_2D_ARRAY, value,
+        if (const int return_value = set_wrap_mode(gl.TexParameteri, GL_TEXTURE_2D_ARRAY, value,
                                                   k.key, k.synonym_key, k.pname,
                                                   k.field_ptr))
         {

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -3219,40 +3219,47 @@ static int MGLSampler_set_wrap(MGLSampler * self, PyObject * value, void * closu
     return 0;
 }
 
-template <class T>
-using SetFunctionPtr = int(*)(T*, PyObject*, void*);
-
-// Helper function to set the repeat texture wrap value
-template <class T>
-static int set_repeat_value(T* self, const SetFunctionPtr<T> set_function, const PyObject* value,
-                            const char* key_string, void* closure)
-{
-    const char * mode_string;
+// Map True/False to a wrap-mode GL constant. Returns 0 on success and writes
+// `*wrap_constant`; returns -1 with a Python error set otherwise.
+static int repeat_value_to_wrap_constant(PyObject * value, const char * axis_name,
+                                         int * wrap_constant) {
     if (value == Py_True) {
-        mode_string = "repeat";
+        *wrap_constant = GL_REPEAT;
     } else if (value == Py_False) {
-        mode_string = "clamp_to_edge";
+        *wrap_constant = GL_CLAMP_TO_EDGE;
     } else {
-        MGLError_Set("invalid value for texture_%s", key_string);
+        MGLError_Set("invalid value for texture_%s", axis_name);
         return -1;
     }
+    return 0;
+}
 
-    PyObject * dict = PyDict_New();
-    PyObject * key = PyUnicode_FromString(key_string);
-    PyObject * str_value = PyUnicode_FromString(mode_string);
-    if (!dict || !key || !str_value) {
-        Py_XDECREF(dict);
-        Py_XDECREF(key);
-        Py_XDECREF(str_value);
+// Apply a wrap-mode constant to a Sampler axis.
+static int set_sampler_wrap_axis(const GLMethods & gl, int sampler_obj, GLenum pname,
+                                 PyObject * value, const char * axis_name, int * cache_field) {
+    int wrap_constant;
+    if (repeat_value_to_wrap_constant(value, axis_name, &wrap_constant)) {
         return -1;
     }
-    PyDict_SetItem(dict, key, str_value);
+    gl.SamplerParameteri(sampler_obj, pname, wrap_constant);
+    *cache_field = wrap_constant;
+    return 0;
+}
 
-    const int return_value = set_function(self, dict, closure);
-    Py_DECREF(str_value);
-    Py_DECREF(key);
-    Py_DECREF(dict);
-    return return_value;
+// Apply a wrap-mode constant to a Texture axis (binds the texture first, since
+// glTexParameteri operates on the currently bound texture).
+static int set_texture_wrap_axis(const GLMethods & gl, int active_unit, int target,
+                                 int texture_obj, GLenum pname,
+                                 PyObject * value, const char * axis_name, int * cache_field) {
+    int wrap_constant;
+    if (repeat_value_to_wrap_constant(value, axis_name, &wrap_constant)) {
+        return -1;
+    }
+    gl.ActiveTexture(GL_TEXTURE0 + active_unit);
+    gl.BindTexture(target, texture_obj);
+    gl.TexParameteri(target, pname, wrap_constant);
+    *cache_field = wrap_constant;
+    return 0;
 }
 
 static PyObject * MGLSampler_get_repeat_x(MGLSampler * self, void * closure) {
@@ -3260,7 +3267,8 @@ static PyObject * MGLSampler_get_repeat_x(MGLSampler * self, void * closure) {
 }
 
 static int MGLSampler_set_repeat_x(MGLSampler * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLSampler_set_wrap, value, "x", closure);
+    return set_sampler_wrap_axis(self->context->gl, self->sampler_obj, GL_TEXTURE_WRAP_S,
+                                 value, "x", &self->wrap_s);
 }
 
 static PyObject * MGLSampler_get_repeat_y(MGLSampler * self, void * closure) {
@@ -3268,7 +3276,8 @@ static PyObject * MGLSampler_get_repeat_y(MGLSampler * self, void * closure) {
 }
 
 static int MGLSampler_set_repeat_y(MGLSampler * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLSampler_set_wrap, value, "y", closure);
+    return set_sampler_wrap_axis(self->context->gl, self->sampler_obj, GL_TEXTURE_WRAP_T,
+                                 value, "y", &self->wrap_t);
 }
 
 static PyObject * MGLSampler_get_repeat_z(MGLSampler * self, void * closure) {
@@ -3276,7 +3285,8 @@ static PyObject * MGLSampler_get_repeat_z(MGLSampler * self, void * closure) {
 }
 
 static int MGLSampler_set_repeat_z(MGLSampler * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLSampler_set_wrap, value, "z", closure);
+    return set_sampler_wrap_axis(self->context->gl, self->sampler_obj, GL_TEXTURE_WRAP_R,
+                                 value, "z", &self->wrap_r);
 }
 
 
@@ -4642,7 +4652,10 @@ static PyObject * MGLTexture_get_repeat_x(MGLTexture * self, void * closure) {
 }
 
 static int MGLTexture_set_repeat_x(MGLTexture * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLTexture_set_wrap, value, "x", closure);
+    const int target = self->samples ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
+    return set_texture_wrap_axis(self->context->gl, self->context->default_texture_unit,
+                                 target, self->texture_obj, GL_TEXTURE_WRAP_S,
+                                 value, "x", &self->wrap_s);
 }
 
 static PyObject * MGLTexture_get_repeat_y(MGLTexture * self, void * closure) {
@@ -4650,7 +4663,10 @@ static PyObject * MGLTexture_get_repeat_y(MGLTexture * self, void * closure) {
 }
 
 static int MGLTexture_set_repeat_y(MGLTexture * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLTexture_set_wrap, value, "y", closure);
+    const int target = self->samples ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
+    return set_texture_wrap_axis(self->context->gl, self->context->default_texture_unit,
+                                 target, self->texture_obj, GL_TEXTURE_WRAP_T,
+                                 value, "y", &self->wrap_t);
 }
 
 static PyObject * MGLTexture_get_filter(MGLTexture * self, void * closure) {
@@ -5328,7 +5344,9 @@ static PyObject * MGLTexture3D_get_repeat_x(MGLTexture3D * self, void * closure)
 }
 
 static int MGLTexture3D_set_repeat_x(MGLTexture3D * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLTexture3D_set_wrap, value, "x", closure);
+    return set_texture_wrap_axis(self->context->gl, self->context->default_texture_unit,
+                                 GL_TEXTURE_3D, self->texture_obj, GL_TEXTURE_WRAP_S,
+                                 value, "x", &self->wrap_s);
 }
 
 static PyObject * MGLTexture3D_get_repeat_y(MGLTexture3D * self, void * closure) {
@@ -5336,7 +5354,9 @@ static PyObject * MGLTexture3D_get_repeat_y(MGLTexture3D * self, void * closure)
 }
 
 static int MGLTexture3D_set_repeat_y(MGLTexture3D * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLTexture3D_set_wrap, value, "y", closure);
+    return set_texture_wrap_axis(self->context->gl, self->context->default_texture_unit,
+                                 GL_TEXTURE_3D, self->texture_obj, GL_TEXTURE_WRAP_T,
+                                 value, "y", &self->wrap_t);
 }
 
 static PyObject * MGLTexture3D_get_repeat_z(MGLTexture3D * self, void * closure) {
@@ -5344,7 +5364,9 @@ static PyObject * MGLTexture3D_get_repeat_z(MGLTexture3D * self, void * closure)
 }
 
 static int MGLTexture3D_set_repeat_z(MGLTexture3D * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLTexture3D_set_wrap, value, "z", closure);
+    return set_texture_wrap_axis(self->context->gl, self->context->default_texture_unit,
+                                 GL_TEXTURE_3D, self->texture_obj, GL_TEXTURE_WRAP_R,
+                                 value, "z", &self->wrap_r);
 }
 
 static PyObject * MGLTexture3D_get_filter(MGLTexture3D * self, void * closure) {
@@ -5974,7 +5996,9 @@ static PyObject * MGLTextureArray_get_repeat_x(MGLTextureArray * self, void * cl
 }
 
 static int MGLTextureArray_set_repeat_x(MGLTextureArray * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLTextureArray_set_wrap, value, "x", closure);
+    return set_texture_wrap_axis(self->context->gl, self->context->default_texture_unit,
+                                 GL_TEXTURE_2D_ARRAY, self->texture_obj, GL_TEXTURE_WRAP_S,
+                                 value, "x", &self->wrap_s);
 }
 
 static PyObject * MGLTextureArray_get_repeat_y(MGLTextureArray * self, void * closure) {
@@ -5982,7 +6006,9 @@ static PyObject * MGLTextureArray_get_repeat_y(MGLTextureArray * self, void * cl
 }
 
 static int MGLTextureArray_set_repeat_y(MGLTextureArray * self, PyObject * value, void * closure) {
-    return set_repeat_value(self, MGLTextureArray_set_wrap, value, "y", closure);
+    return set_texture_wrap_axis(self->context->gl, self->context->default_texture_unit,
+                                 GL_TEXTURE_2D_ARRAY, self->texture_obj, GL_TEXTURE_WRAP_T,
+                                 value, "y", &self->wrap_t);
 }
 
 static PyObject * MGLTextureArray_get_filter(MGLTextureArray * self, void * closure) {

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -3227,16 +3227,23 @@ template <class T>
 static int set_repeat_value(T* self, const SetFunctionPtr<T> set_function, const PyObject* value,
                             const char* key_string, void* closure)
 {
-    PyObject* dict = PyDict_New();
-    PyObject* key = PyUnicode_FromString(key_string);
-    PyObject* str_value = (value == Py_True)
-                              ? PyUnicode_FromString("repeat")
-                              : (value == Py_False)
-                              ? PyUnicode_FromString("clamp_to_edge")
-                              : nullptr;
-    if (!str_value)
-    {
+    const char * mode_string;
+    if (value == Py_True) {
+        mode_string = "repeat";
+    } else if (value == Py_False) {
+        mode_string = "clamp_to_edge";
+    } else {
         MGLError_Set("invalid value for texture_%s", key_string);
+        return -1;
+    }
+
+    PyObject * dict = PyDict_New();
+    PyObject * key = PyUnicode_FromString(key_string);
+    PyObject * str_value = PyUnicode_FromString(mode_string);
+    if (!dict || !key || !str_value) {
+        Py_XDECREF(dict);
+        Py_XDECREF(key);
+        Py_XDECREF(str_value);
         return -1;
     }
     PyDict_SetItem(dict, key, str_value);

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -1,7 +1,5 @@
 #define PY_SSIZE_T_CLEAN
-#include <functional>
 #include <Python.h>
-#include <string>
 
 #include "gl_methods.hpp"
 
@@ -3131,7 +3129,7 @@ static int SetWrapMode(const GLMethodPtr gl_method, const int field, PyObject* u
     {
         if (v && !PyUnicode_Check(v))
         {
-            MGLError_Set(("Value for key "+ std::string(k) + " must be a string").c_str());
+            MGLError_Set("Value for key %s must be a string", k);
             return -1;
         }
     }
@@ -3139,8 +3137,8 @@ static int SetWrapMode(const GLMethodPtr gl_method, const int field, PyObject* u
     if (wrap_obj && synonym_wrap_obj && PyUnicode_Compare(wrap_obj, synonym_wrap_obj) != 0)
     {
         MGLError_Set(
-            (" Both the key '"+ std::string(key) + "' and its synonym '"+ std::string(synonym_key) +
-                "' were given, but with different values").c_str());
+            " Both the key '%s' and its synonym '%s' were given, but with different values",
+            key, synonym_key);
         return -1;
     }
 
@@ -3155,7 +3153,7 @@ static int SetWrapMode(const GLMethodPtr gl_method, const int field, PyObject* u
     const int wrap_constant = wrap_string_to_constant(wrap_str);
     if (!wrap_constant)
     {
-        MGLError_Set(("invalid wrap mode for '" + std::string(key_used) + "'").c_str());
+        MGLError_Set("invalid wrap mode for '%s'", key_used);
         return -1;
     }
     gl_method(field, pname, wrap_constant);
@@ -3232,7 +3230,7 @@ static int set_repeat_value(T* self, const SetFunctionPtr<T> set_function, const
                               : nullptr;
     if (!str_value)
     {
-        MGLError_Set((std::string("invalid value for texture_") + std::string(key_string)).c_str());
+        MGLError_Set("invalid value for texture_%s", key_string);
         return -1;
     }
     PyDict_SetItem(dict, key, str_value);

--- a/src/moderngl.cpp
+++ b/src/moderngl.cpp
@@ -3112,6 +3112,18 @@ static int GetWrapMode(PyObject * wrap_dict, const char* key, const int mode)
 
 using GLMethodPtr = void(*)(GLuint, GLenum, GLint);
 
+struct WrapField {
+    const char * key;
+    int field_value;
+};
+
+struct WrapKey {
+    const char * key;
+    const char * synonym_key;
+    GLenum pname;
+    int * field_ptr;
+};
+
 // Helper function to set a texture wrapping mode
 static int SetWrapMode(const GLMethodPtr gl_method, const int field, PyObject* update_dict,
                        const char* key, const char* synonym_key, const GLenum pname, int* wrap_mode)
@@ -3123,15 +3135,13 @@ static int SetWrapMode(const GLMethodPtr gl_method, const int field, PyObject* u
         return 0; // Okay for neither to exist
     }
     // If either key is given, then the value must be a string
-    for (const auto& [k, v] : {
-             std::make_pair(key, wrap_obj), std::make_pair(synonym_key, synonym_wrap_obj)
-         })
-    {
-        if (v && !PyUnicode_Check(v))
-        {
-            MGLError_Set("Value for key %s must be a string", k);
-            return -1;
-        }
+    if (wrap_obj && !PyUnicode_Check(wrap_obj)) {
+        MGLError_Set("Value for key %s must be a string", key);
+        return -1;
+    }
+    if (synonym_wrap_obj && !PyUnicode_Check(synonym_wrap_obj)) {
+        MGLError_Set("Value for key %s must be a string", synonym_key);
+        return -1;
     }
     // If both exist, the values must be the same
     if (wrap_obj && synonym_wrap_obj && PyUnicode_Compare(wrap_obj, synonym_wrap_obj) != 0)
@@ -3169,15 +3179,13 @@ static PyObject * MGLSampler_get_wrap(const MGLSampler * self, void * closure) {
     }
 
     // Use the "x", "y", "z" keys to be consistent with other usage in moderngl
-    std::vector<std::tuple<const char*,int>> wrap_fields = {
+    const WrapField wrap_fields[] = {
         {"x", self->wrap_s},
         {"y", self->wrap_t},
-        {"z", self->wrap_r}
+        {"z", self->wrap_r},
     };
-    for (const auto [key, field_value] : wrap_fields)
-    {
-        if (GetWrapMode(wrap_dict, key, field_value))
-        {
+    for (const WrapField & wf : wrap_fields) {
+        if (GetWrapMode(wrap_dict, wf.key, wf.field_value)) {
             Py_DECREF(wrap_dict);
             return nullptr;
         }
@@ -3195,17 +3203,15 @@ static int MGLSampler_set_wrap(MGLSampler * self, PyObject * value, void * closu
         return -1;
     }
 
-    std::vector<std::tuple<const char*, const char*, GLenum, int*>> known_keys = {
+    const WrapKey known_keys[] = {
         {"x", "s", GL_TEXTURE_WRAP_S, &self->wrap_s},
         {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
-        {"z", "r", GL_TEXTURE_WRAP_R, &self->wrap_r}
+        {"z", "r", GL_TEXTURE_WRAP_R, &self->wrap_r},
     };
-    for (const auto [key, synonym_key, pname, field_ptr] : known_keys)
-    {
-        // Process key if present
-        if (const auto return_value = SetWrapMode(gl.SamplerParameteri, self->sampler_obj,
-                                                       value, key, synonym_key, pname, field_ptr))
-        {
+    for (const WrapKey & k : known_keys) {
+        if (const int return_value = SetWrapMode(gl.SamplerParameteri, self->sampler_obj,
+                                                  value, k.key, k.synonym_key, k.pname,
+                                                  k.field_ptr)) {
             return return_value;
         }
     }
@@ -4583,14 +4589,12 @@ static PyObject * MGLTexture_get_wrap(const MGLTexture * self, void * closure) {
     }
 
     // Use the "x", "y" keys to be consistent with other usage in moderngl
-    std::vector<std::tuple<const char*,int>> wrap_fields = {
+    const WrapField wrap_fields[] = {
         {"x", self->wrap_s},
         {"y", self->wrap_t},
     };
-    for (const auto [key, field_value] : wrap_fields)
-    {
-        if (GetWrapMode(wrap_dict, key, field_value))
-        {
+    for (const WrapField & wf : wrap_fields) {
+        if (GetWrapMode(wrap_dict, wf.key, wf.field_value)) {
             Py_DECREF(wrap_dict);
             return nullptr;
         }
@@ -4608,16 +4612,17 @@ static int MGLTexture_set_wrap(MGLTexture * self, PyObject * value, void * closu
     }
     const int texture_target = self->samples ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
 
-    std::vector<std::tuple<const char*, const char*, GLint, int*>> known_keys = {
+    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+    gl.BindTexture(texture_target, self->texture_obj);
+
+    const WrapKey known_keys[] = {
         {"x", "s", GL_TEXTURE_WRAP_S, &self->wrap_s},
         {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
     };
-    for (const auto [key, synonym_key, pname, field_ptr] : known_keys)
-    {
-        // Process key if present
-        if (const auto return_value = SetWrapMode(gl.TexParameteri, texture_target, value, key,
-                                                       synonym_key, pname, field_ptr))
-        {
+    for (const WrapKey & k : known_keys) {
+        if (const int return_value = SetWrapMode(gl.TexParameteri, texture_target, value,
+                                                  k.key, k.synonym_key, k.pname,
+                                                  k.field_ptr)) {
             return return_value;
         }
     }
@@ -5269,15 +5274,13 @@ static PyObject *MGLTexture3D_get_wrap(const MGLTexture3D * self, void * closure
     }
 
     // Use the "x", "y", "z" keys to be consistent with other usage in moderngl
-    std::vector<std::tuple<const char*,int>> wrap_fields = {
+    const WrapField wrap_fields[] = {
         {"x", self->wrap_s},
         {"y", self->wrap_t},
-        {"z", self->wrap_r}
+        {"z", self->wrap_r},
     };
-    for (const auto [key, field_value] : wrap_fields)
-    {
-        if (GetWrapMode(wrap_dict, key, field_value))
-        {
+    for (const WrapField & wf : wrap_fields) {
+        if (GetWrapMode(wrap_dict, wf.key, wf.field_value)) {
             Py_DECREF(wrap_dict);
             return nullptr;
         }
@@ -5294,17 +5297,18 @@ static int MGLTexture3D_set_wrap(MGLTexture3D * self, PyObject * value, void * c
         return -1;
     }
 
-    std::vector<std::tuple<const char*, const char*, GLenum, int*>> known_keys = {
+    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+    gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+    const WrapKey known_keys[] = {
         {"x", "s", GL_TEXTURE_WRAP_S, &self->wrap_s},
         {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
         {"z", "r", GL_TEXTURE_WRAP_R, &self->wrap_r},
     };
-    for (const auto [key, synonym_key, pname, field_ptr] : known_keys)
-    {
-        // Process key if present
-        if (const auto return_value = SetWrapMode(gl.TexParameteri, GL_TEXTURE_3D, value, key,
-                                                       synonym_key, pname, field_ptr))
-        {
+    for (const WrapKey & k : known_keys) {
+        if (const int return_value = SetWrapMode(gl.TexParameteri, GL_TEXTURE_3D, value,
+                                                  k.key, k.synonym_key, k.pname,
+                                                  k.field_ptr)) {
             return return_value;
         }
     }
@@ -5917,14 +5921,12 @@ static PyObject * MGLTextureArray_get_wrap(const MGLTextureArray * self, void * 
     }
 
     // Use the "x", "y" keys to be consistent with other usage in moderngl
-    std::vector<std::tuple<const char*,int>> wrap_fields = {
+    const WrapField wrap_fields[] = {
         {"x", self->wrap_s},
         {"y", self->wrap_t},
     };
-    for (const auto [key, field_value] : wrap_fields)
-    {
-        if (GetWrapMode(wrap_dict, key, field_value))
-        {
+    for (const WrapField & wf : wrap_fields) {
+        if (GetWrapMode(wrap_dict, wf.key, wf.field_value)) {
             Py_DECREF(wrap_dict);
             return nullptr;
         }
@@ -5941,15 +5943,17 @@ static int MGLTextureArray_set_wrap(MGLTextureArray * self, PyObject * value, vo
         return -1;
     }
 
-    std::vector<std::tuple<const char*, const char*, GLint, int*>> known_keys = {
+    gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+    gl.BindTexture(GL_TEXTURE_2D_ARRAY, self->texture_obj);
+
+    const WrapKey known_keys[] = {
         {"x", "s", GL_TEXTURE_WRAP_S, &self->wrap_s},
         {"y", "t", GL_TEXTURE_WRAP_T, &self->wrap_t},
     };
-    for (const auto [key, synonym_key, pname, field_ptr] : known_keys)
-    {
-        // Process key if present
-        if (const auto return_value = SetWrapMode(gl.TexParameteri, GL_TEXTURE_2D_ARRAY, value,
-                                                   key, synonym_key, pname, field_ptr))
+    for (const WrapKey & k : known_keys) {
+        if (const int return_value = SetWrapMode(gl.TexParameteri, GL_TEXTURE_2D_ARRAY, value,
+                                                  k.key, k.synonym_key, k.pname,
+                                                  k.field_ptr))
         {
             return return_value;
         }

--- a/tests/test_depth_samplers.py
+++ b/tests/test_depth_samplers.py
@@ -346,8 +346,7 @@ def test_sampler_shadow_with_bilinear_interpolation(
 
     def _with_texture_parameters():
         tex_depth.filter = depth_tex_filter
-        tex_depth.repeat_x = False
-        tex_depth.repeat_y = False
+        tex_depth.wrap = {'x' : 'clamp_to_edge', 'y' : 'clamp_to_edge'}
         tex_depth.compare_func = compare_func
         _do_test()
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -13,6 +13,7 @@ def test_defaults(ctx):
     assert sampler.repeat_x is True
     assert sampler.repeat_y is True
     assert sampler.repeat_z is True
+    assert dict(sampler.wrap) == {'x' : 'repeat', 'y' : 'repeat', 'z' : 'repeat'}
     assert sampler.filter == (moderngl.LINEAR, moderngl.LINEAR)
     assert sampler.compare_func == '?'
     assert sampler.border_color == (0.0, 0.0, 0.0, 0.0)
@@ -38,6 +39,29 @@ def test_prop_changes(ctx):
     assert (sampler.repeat_x, sampler.repeat_y, sampler.repeat_z) == (False, False, True)
     sampler.repeat_z = False
     assert (sampler.repeat_x, sampler.repeat_y, sampler.repeat_z) == (False, False, False)
+
+    sampler.wrap = {'x' : 'repeat', 'y' : 'repeat', 'z' : 'repeat'}
+    other_wrap_modes = ['clamp_to_edge', 'clamp_to_border', 'mirrored_repeat',
+                        'mirror_clamp_to_edge']
+    for other_wrap_mode in other_wrap_modes:
+        sampler.wrap = {'x' : other_wrap_mode}
+        assert (sampler.wrap['x'] == other_wrap_mode and
+                 sampler.wrap['y'] == 'repeat' and
+                 sampler.wrap['z'] == 'repeat')
+        sampler.wrap = {'y' : other_wrap_mode}
+        assert (sampler.wrap['x'] == other_wrap_mode and
+                sampler.wrap['y'] == other_wrap_mode and
+                sampler.wrap['z'] == 'repeat')
+        sampler.wrap = {'z' : other_wrap_mode}
+        assert (sampler.wrap['x'] == other_wrap_mode and
+                sampler.wrap['y'] == other_wrap_mode and
+                sampler.wrap['z'] == other_wrap_mode)
+        sampler.wrap = {'x' : 'repeat', 'y' : 'repeat', 'z' : 'repeat'}
+        sampler.wrap = {'x' : other_wrap_mode, 'y' : other_wrap_mode}
+        assert (sampler.wrap['x'] == other_wrap_mode and
+                sampler.wrap['y'] == other_wrap_mode and
+                sampler.wrap['z'] == 'repeat')
+        sampler.wrap = {'x' : 'repeat', 'y' : 'repeat', 'z' : 'repeat'}
 
 
 def test_border_color(ctx):

--- a/tests/test_simple_texture_3d.py
+++ b/tests/test_simple_texture_3d.py
@@ -15,6 +15,7 @@ def test_properties(ctx):
     assert tex.repeat_x is True
     assert tex.repeat_y is True
     assert tex.repeat_z is True
+    assert dict(tex.wrap) == {'x' : 'repeat', 'y' : 'repeat', 'z' : 'repeat'}
     assert tex == tex
 
     tex.repeat_x = False
@@ -23,6 +24,13 @@ def test_properties(ctx):
     assert tex.repeat_x is False
     assert tex.repeat_y is False
     assert tex.repeat_z is False
+    assert dict(tex.wrap) == {'x' : 'clamp_to_edge', 'y' : 'clamp_to_edge', 'z' : 'clamp_to_edge'}
+    tex.wrap['z'] = 'repeat'
+    assert dict(tex.wrap) == {'x' : 'clamp_to_edge', 'y' : 'clamp_to_edge', 'z' : 'repeat'}
+    assert tex.wrap['z'] == 'repeat'
+    assert tex.repeat_x is False
+    assert tex.repeat_y is False
+    assert tex.repeat_z is True
 
 
 def test_mipmaps(ctx):

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -71,10 +71,10 @@ def test_texture_properties(ctx):
     assert invalid_value_exception_caught
     try:
         tex.wrap['invalid'] = 'repeat'
-        unknown_key_ignored = True
-    except RuntimeError:
-        unknown_key_ignored = False
-    assert unknown_key_ignored
+        unknown_key_raised = False
+    except KeyError:
+        unknown_key_raised = True
+    assert unknown_key_raised
     assert tex.dtype == 'f1'
     assert tex.anisotropy == 0.0
 

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -42,6 +42,39 @@ def test_texture_properties(ctx):
     assert tex.filter == (moderngl.LINEAR, moderngl.LINEAR)
     assert tex.repeat_x is True
     assert tex.repeat_y is True
+    assert dict(tex.wrap) == {"x": "repeat", "y": "repeat"}
+    tex.wrap = {"x": "repeat", "y": "repeat", "z": "repeat"}  # ignores the "z" key for Texture
+    assert dict(tex.wrap) == {"x": "repeat", "y": "repeat"}
+    tex.wrap = {"s": "mirrored_repeat", "t": "clamp_to_edge"}  # "s" and "t" are synonyms for "x" and "y"
+    assert dict(tex.wrap) == {"x": "mirrored_repeat", "y": "clamp_to_edge"}
+    tex.wrap['x'] = 'repeat'  # Set just one of the values
+    assert dict(tex.wrap) == {"x": "repeat", "y": "clamp_to_edge"}
+    try:
+        # if "s" and "x" (or "t" and "y", or "r" and "z") are both present, they must be the same
+        tex.wrap = {"s": "mirrored_repeat", "x": "clamp_to_edge"}
+        exception_caught = False
+    except moderngl.Error:
+        exception_caught = True
+    assert exception_caught
+    try:
+        # if "s" and "x" (or "t" and "y", or "r" and "z") are both present, they can be the same
+        tex.wrap = {"y": "mirrored_repeat", "t": "mirrored_repeat"}
+        duplicate_allowed = True
+    except moderngl.Error as e:
+        duplicate_allowed = False
+    assert duplicate_allowed
+    try:
+        tex.wrap['x'] = 'invalid'
+        invalid_value_exception_caught = False
+    except moderngl.Error:
+        invalid_value_exception_caught = True
+    assert invalid_value_exception_caught
+    try:
+        tex.wrap['invalid'] = 'repeat'
+        unknown_key_ignored = True
+    except RuntimeError:
+        unknown_key_ignored = False
+    assert unknown_key_ignored
     assert tex.dtype == 'f1'
     assert tex.anisotropy == 0.0
 

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -49,32 +49,15 @@ def test_texture_properties(ctx):
     assert dict(tex.wrap) == {"x": "mirrored_repeat", "y": "clamp_to_edge"}
     tex.wrap['x'] = 'repeat'  # Set just one of the values
     assert dict(tex.wrap) == {"x": "repeat", "y": "clamp_to_edge"}
-    try:
-        # if "s" and "x" (or "t" and "y", or "r" and "z") are both present, they must be the same
+    # if "s" and "x" (or "t" and "y", or "r" and "z") are both present, they must be the same
+    with pytest.raises(moderngl.Error):
         tex.wrap = {"s": "mirrored_repeat", "x": "clamp_to_edge"}
-        exception_caught = False
-    except moderngl.Error:
-        exception_caught = True
-    assert exception_caught
-    try:
-        # if "s" and "x" (or "t" and "y", or "r" and "z") are both present, they can be the same
-        tex.wrap = {"y": "mirrored_repeat", "t": "mirrored_repeat"}
-        duplicate_allowed = True
-    except moderngl.Error as e:
-        duplicate_allowed = False
-    assert duplicate_allowed
-    try:
+    # if "s" and "x" (or "t" and "y", or "r" and "z") are both present, they can be the same
+    tex.wrap = {"y": "mirrored_repeat", "t": "mirrored_repeat"}
+    with pytest.raises(moderngl.Error):
         tex.wrap['x'] = 'invalid'
-        invalid_value_exception_caught = False
-    except moderngl.Error:
-        invalid_value_exception_caught = True
-    assert invalid_value_exception_caught
-    try:
+    with pytest.raises(KeyError):
         tex.wrap['invalid'] = 'repeat'
-        unknown_key_raised = False
-    except KeyError:
-        unknown_key_raised = True
-    assert unknown_key_raised
     assert tex.dtype == 'f1'
     assert tex.anisotropy == 0.0
 

--- a/tests/test_texture_array.py
+++ b/tests/test_texture_array.py
@@ -17,6 +17,7 @@ def test_create(ctx):
     # Texture parameters
     assert texture.repeat_x is True
     assert texture.repeat_y is True
+    assert dict(texture.wrap) == {'x': 'repeat', 'y': 'repeat'}
     assert texture.filter == (moderngl.LINEAR, moderngl.LINEAR)
     assert texture.swizzle == "RGBA"
     assert texture == texture
@@ -25,6 +26,7 @@ def test_create(ctx):
     texture.repeat_y = False
     assert texture.repeat_x is False
     assert texture.repeat_y is False
+    assert dict(texture.wrap) == {'x': 'clamp_to_edge', 'y': 'clamp_to_edge'}
 
     assert texture.swizzle == "RGBA"
     texture.swizzle = "RGBA"

--- a/tests/test_texture_external.py
+++ b/tests/test_texture_external.py
@@ -18,6 +18,7 @@ def test_init_from_texture_and_params(ctx):
     assert ext.samples == params_tex["samples"]
     assert ext.repeat_x is True
     assert ext.repeat_y is True
+    assert dict(ext.wrap) == {'x': 'repeat', 'y': 'repeat'}
     assert ext.filter == (ctx.LINEAR, ctx.LINEAR)
     assert ext.swizzle == "RGBA"
     assert ext.depth is False

--- a/tests/test_wrap_gl_state.py
+++ b/tests/test_wrap_gl_state.py
@@ -1,0 +1,73 @@
+"""
+Verifies that setting `wrap` actually changes the OpenGL state on the intended
+texture, not whatever happens to be bound at the time of the call.
+
+These tests catch the failure mode where the wrap setter calls
+`glTexParameteri(target, ...)` without first binding `self->texture_obj` to
+that target — the parameter would silently land on whichever texture was
+last bound (e.g. a more recently created one).
+"""
+import OpenGL
+OpenGL.ERROR_CHECKING = False  # Don't want PyOpenGL to raise on its own
+from OpenGL import GL
+
+
+def _query_wrap(target, pname):
+    """Reads a single GL_TEXTURE_WRAP_* parameter from the texture currently
+    bound to `target` on the active texture unit."""
+    out = (GL.GLint * 1)()
+    GL.glGetTexParameteriv(target, pname, out)
+    return out[0]
+
+
+def test_texture_wrap_applies_to_self_not_bound_texture(ctx):
+    tex_a = ctx.texture((4, 4), 4)
+    # Creating tex_b leaves it bound to the default texture unit on
+    # GL_TEXTURE_2D, displacing tex_a's binding.
+    tex_b = ctx.texture((4, 4), 4)
+
+    tex_a.wrap = {"x": "clamp_to_edge", "y": "mirrored_repeat"}
+
+    tex_a.use(0)
+    assert GL.GL_CLAMP_TO_EDGE == _query_wrap(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S)
+    assert GL.GL_MIRRORED_REPEAT == _query_wrap(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T)
+
+    tex_b.use(0)
+    assert GL.GL_REPEAT == _query_wrap(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S)
+    assert GL.GL_REPEAT == _query_wrap(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T)
+
+
+def test_texture3d_wrap_applies_to_self_not_bound_texture(ctx):
+    tex_a = ctx.texture3d((4, 4, 4), 4)
+    tex_b = ctx.texture3d((4, 4, 4), 4)
+
+    tex_a.wrap = {
+        "x": "clamp_to_edge",
+        "y": "mirrored_repeat",
+        "z": "clamp_to_border",
+    }
+
+    tex_a.use(0)
+    assert GL.GL_CLAMP_TO_EDGE == _query_wrap(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_S)
+    assert GL.GL_MIRRORED_REPEAT == _query_wrap(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_T)
+    assert GL.GL_CLAMP_TO_BORDER == _query_wrap(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_R)
+
+    tex_b.use(0)
+    assert GL.GL_REPEAT == _query_wrap(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_S)
+    assert GL.GL_REPEAT == _query_wrap(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_T)
+    assert GL.GL_REPEAT == _query_wrap(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_R)
+
+
+def test_texture_array_wrap_applies_to_self_not_bound_texture(ctx):
+    tex_a = ctx.texture_array((4, 4, 2), 4)
+    tex_b = ctx.texture_array((4, 4, 2), 4)
+
+    tex_a.wrap = {"x": "clamp_to_edge", "y": "mirrored_repeat"}
+
+    tex_a.use(0)
+    assert GL.GL_CLAMP_TO_EDGE == _query_wrap(GL.GL_TEXTURE_2D_ARRAY, GL.GL_TEXTURE_WRAP_S)
+    assert GL.GL_MIRRORED_REPEAT == _query_wrap(GL.GL_TEXTURE_2D_ARRAY, GL.GL_TEXTURE_WRAP_T)
+
+    tex_b.use(0)
+    assert GL.GL_REPEAT == _query_wrap(GL.GL_TEXTURE_2D_ARRAY, GL.GL_TEXTURE_WRAP_S)
+    assert GL.GL_REPEAT == _query_wrap(GL.GL_TEXTURE_2D_ARRAY, GL.GL_TEXTURE_WRAP_T)

--- a/tests/test_wrap_proxy.py
+++ b/tests/test_wrap_proxy.py
@@ -2,6 +2,10 @@
 Tests for the Python-side WrapProxy that backs the `wrap` property on
 Sampler, Texture, Texture3D, and TextureArray.
 """
+import gc
+import sys
+
+import moderngl
 
 
 def test_wrap_proxy_len(ctx):
@@ -17,3 +21,38 @@ def test_wrap_proxy_len(ctx):
 
     tex_array = ctx.texture_array((4, 4, 2), 4)
     assert 2 == len(tex_array.wrap)
+
+
+def test_set_repeat_value_no_leak_on_invalid_value(ctx):
+    """Regression: assigning a non-bool to `repeat_*` used to leak a dict
+    per call. set_repeat_value allocated `dict` and `key` up front and
+    returned -1 on the invalid-value path without DECREFing them.
+
+    `sys.getallocatedblocks()` exposes the leak even though the empty
+    dict isn't gc-tracked (CPython skips tracking dicts that can't form
+    cycles)."""
+    tex = ctx.texture((4, 4), 4)
+
+    # Warm-up to settle any one-time allocations.
+    for _ in range(10):
+        try:
+            tex.repeat_x = "warm-up"
+        except moderngl.Error:
+            pass
+    gc.collect()
+
+    n_before = sys.getallocatedblocks()
+
+    iterations = 1000
+    for _ in range(iterations):
+        try:
+            tex.repeat_x = "not a bool"
+        except moderngl.Error:
+            pass
+
+    gc.collect()
+    leaked = sys.getallocatedblocks() - n_before
+
+    assert leaked < 100, (
+        f"leaked {leaked} allocated blocks over {iterations} invalid assignments"
+    )

--- a/tests/test_wrap_proxy.py
+++ b/tests/test_wrap_proxy.py
@@ -5,6 +5,8 @@ Sampler, Texture, Texture3D, and TextureArray.
 import gc
 import sys
 
+import pytest
+
 import moderngl
 
 
@@ -29,20 +31,12 @@ def test_wrap_proxy_setitem_unknown_key_raises(ctx):
     stays lenient by design (see test_texture.py for the cross-type
     extras case)."""
     tex2d = ctx.texture((4, 4), 4)
-    try:
+    with pytest.raises(KeyError):
         tex2d.wrap['z'] = 'repeat'  # Texture has no z axis
-    except KeyError:
-        pass
-    else:
-        assert False, "expected KeyError on subscript with unknown key"
 
     sampler = ctx.sampler()
-    try:
+    with pytest.raises(KeyError):
         sampler.wrap['typo'] = 'repeat'
-    except KeyError:
-        pass
-    else:
-        assert False, "expected KeyError on subscript with unknown key"
 
     # Synonyms are valid and must not raise.
     sampler.wrap['s'] = 'repeat'

--- a/tests/test_wrap_proxy.py
+++ b/tests/test_wrap_proxy.py
@@ -23,6 +23,33 @@ def test_wrap_proxy_len(ctx):
     assert 2 == len(tex_array.wrap)
 
 
+def test_wrap_proxy_setitem_unknown_key_raises(ctx):
+    """Subscript assignment with a key the texture type doesn't have
+    should raise KeyError, not silently no-op. Whole-dict assignment
+    stays lenient by design (see test_texture.py for the cross-type
+    extras case)."""
+    tex2d = ctx.texture((4, 4), 4)
+    try:
+        tex2d.wrap['z'] = 'repeat'  # Texture has no z axis
+    except KeyError:
+        pass
+    else:
+        assert False, "expected KeyError on subscript with unknown key"
+
+    sampler = ctx.sampler()
+    try:
+        sampler.wrap['typo'] = 'repeat'
+    except KeyError:
+        pass
+    else:
+        assert False, "expected KeyError on subscript with unknown key"
+
+    # Synonyms are valid and must not raise.
+    sampler.wrap['s'] = 'repeat'
+    sampler.wrap['t'] = 'repeat'
+    sampler.wrap['r'] = 'repeat'
+
+
 def test_set_repeat_value_no_leak_on_invalid_value(ctx):
     """Regression: assigning a non-bool to `repeat_*` used to leak a dict
     per call. set_repeat_value allocated `dict` and `key` up front and

--- a/tests/test_wrap_proxy.py
+++ b/tests/test_wrap_proxy.py
@@ -1,0 +1,19 @@
+"""
+Tests for the Python-side WrapProxy that backs the `wrap` property on
+Sampler, Texture, Texture3D, and TextureArray.
+"""
+
+
+def test_wrap_proxy_len(ctx):
+    """`len(obj.wrap)` should report the number of wrap axes."""
+    sampler = ctx.sampler()
+    assert 3 == len(sampler.wrap)
+
+    tex2d = ctx.texture((4, 4), 4)
+    assert 2 == len(tex2d.wrap)
+
+    tex3d = ctx.texture3d((4, 4, 4), 4)
+    assert 3 == len(tex3d.wrap)
+
+    tex_array = ctx.texture_array((4, 4, 2), 4)
+    assert 2 == len(tex_array.wrap)


### PR DESCRIPTION
The current texture wrapping modes supported by the package are `repeat` or `clamp to edge`, and the setting is controlled by a set of boolean properties on the objects that have wrapping modes (`Sampler`, `Texture`, `Texture3D`, and `TextureArray`).  

The interface shall be changed to support the full set of wrapping modes, but still maintain moderngl API compatibility.  The wrapping modes are `repeat`, `clamp_to_edge`, `clamp_to_border`, `mirrored_repeat`, and `mirror_clamp_to_edge`.

A new field `wrap` shall be added to the above objects, which may be set by a dictionary of wrapping mode values, keyed by the axes that they apply to.  To maintain compatibility with the convention in ModernGL, the names of the axes shall be "x", "y" and "z", but the synonyms "s", "t", "r" shall also be accepted when setting the values. (The synonyms match the OpenGL convention for the labelling of the axes).

The value for the wrapping mode shall be one of those in the above list of values.

When a change to the wrapping mode is made either directly through the new `wrap` property or through the previous repeat_[xyz] interface, the result shall be consistent: for example, setting the wrap property for the 'x' axis to `repeat` shall set the `repeat_x` property to `True`, and vice-versa.  Setting the `repeat_x` property to `False`, shall set the `wrap['x']` property to `clamp_to_edge`, which is the same as previously.  If the `wrap['x']` property is set to one of the other wrapping modes, then the `repeat_x` property shall also be set to `False`.

The values for all axes may be changed at the same time, by setting the `wrap` property to a dictionary; for example: 

```
texture.wrap = {"x": "mirrored_repeat", "y": "clamp_to_edge"}
```

or individually:

```
texture.wrap["x"] = "mirrored_repeat"
texture.wrap["y"] = "clamp_to_edge"
```

If a wrap property is set using a dictionary, then only the keys that are recognized by the object shall be used.  For example, the `Texture` object only uses the "x" and "y" axes, but if the dictionary contains the "z" key too, that key shall be ignored.  If the dictionary contains both the principal axis name and its synonym (for example, "x" and "s"), the values must be the same, otherwise an exception shall be raised.
